### PR TITLE
LSI-253 Reduce runtime of build-and-push-image job

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY scripts ./scripts
 COPY src ./src
 COPY bin ./bin
 
-RUN npm install
+RUN npm clean-install
 
 # Make scripts executable
 RUN chmod +x ./bin/*

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "start:http": "node dist/indexHttp.esm.js",
     "dev": "cross-env NODE_OPTIONS=\"--no-warnings --loader ts-node/esm\" node src/index.ts",
     "dev:http": "cross-env NODE_OPTIONS=\"--no-warnings --loader ts-node/esm\" node src/indexHttp.ts",
-    "prepare": "npm run build",
     "test": "vitest run --coverage",
     "test:watch": "vitest --watch",
     "test:ui": "vitest --ui",


### PR DESCRIPTION
* Reduces the runtime of the Build / build-and-push-image job from ~40 min to ~20 min by not running `npm run build` as part of the prepare script. The prepare script is triggered after `npm install` (or `clean-install`). The Dockerfile was first running `npm install` and then `npm run build`, effectively building the project twice instead of once. I chose to solve this by not running `npm run build` via prepare because I found it confusing: after installing dependencies the project was automatically built but not after making a source file change. I think it's still useful to have some mechanism that automatically installs deps or builds if needed, but I recommend we use another, more suitable tool for that like Make.
* Updates the Dockerfile to call `npm clean-install` instead of `npm install`. `clean-install` is more appropriate, because it fails if there's a mismatch between `package.json` and `package-lock.json` and never adds or changes dependencies.