### PR TITLE
LSI-0 Enable sandbox for Claude Code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,5 +2,9 @@
   "permissions": {
     "allow": ["Bash(npm run test)"],
     "deny": ["Read(.env)"]
+  },
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": true
   }
 }


### PR DESCRIPTION
This ensures that Claude Code can freely read and run Bash utilities within the repo but not outside. Network operations will also be blocked by default. If Claude needs to perform an operation that is blocked by the sandbox, it can still run it outside of the sandbox and then it requires approvals as usual.