### PR TITLE
LSI-212 Speed up Docker build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - '**'  # Build on all branches
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 permissions:
   contents: read
   packages: write
@@ -34,45 +30,27 @@ jobs:
           fi
 
   build-and-push-image:
-    runs-on: ubuntu-22.04
     needs: [pre-check]
     if: ${{ needs.pre-check.outputs.skip-workflow == 'false' }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
+    uses: docker/github-builder/.github/workflows/build.yml@v1
+    permissions:
+      contents: read
+      packages: write
+    with:
+      output: image
+      push: true
+      platforms: linux/amd64,linux/arm64
+      meta-images: ghcr.io/${{ github.repository }}
+      meta-tags: |
+        type=ref,event=branch
+        type=ref,event=pr
+        type=sha,prefix=sha-
+      build-args: |
+        VERSION=${{ github.sha }}
+      sign: false
+      cache: true
+    secrets:
+      registry-auths: |
+        - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=sha,prefix=sha-
-
-      - name: Build and push Docker image
-        id: build-and-push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VERSION=${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max


### PR DESCRIPTION
Speed up the Docker build job by using the official reusable workflow from Docker `docker/github-builder/.github/workflows/build.yml`, which runs each target as a separate job on the target's architecture.

**The end result is that the build-and-push-image job now only takes around 4 minutes instead of 20.**

So now the Build / build-and-push-image status check is replaced by two new ones:
* Build / build-and-push-image / build (0, linux/amd64, ubuntu-24.04) (push)
* Build / build-and-push-image / build (1, linux/arm64, ubuntu-24.04-arm) (push)

Note that Build / build-and-push-image is still a required status check for PRs, which is why the build is failing. As you can see, the two new checks passed. After the PR has been merged I'll update the ruleset to require only the two new status checks.

I've verified that both the ARM and the AMD images can be pulled and run on my machine.