### PR TITLE
LSI-305 Add workflow_dispatch to prepare-release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -3,6 +3,12 @@ name: Prepare release
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name (e.g. v1.2.3)'
+        required: true
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -11,11 +17,11 @@ env:
 jobs:
   update-package-version-and-push-commit:
     runs-on: ubuntu-22.04
-    if: ${{ startsWith(github.event.release.tag_name, 'v') }}
+    if: ${{ startsWith(github.event.release.tag_name || inputs.tag_name, 'v') }}
     permissions:
       contents: write
     env:
-      TAG_NAME: ${{ github.event.release.tag_name }}
+      TAG_NAME: ${{ github.event.release.tag_name || inputs.tag_name }}
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
So that it can manually be rerun on failure

I cannot test this manually without first merging this PR into main.