### PR TITLE
LSI-305 Make prepare-release idempotent

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -41,7 +41,27 @@ jobs:
           version_number=$(echo "$TAG_NAME" | sed 's/^v//')
           sed -i "s/export const VERSION = \".*\";/export const VERSION = \"${version_number}\";/" src/version.ts
 
+      - name: check-changes
+        id: check
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: check-version
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          old=$(git show HEAD:package.json | yq -r .version)
+          new=$(yq -r .version package.json)
+          if [[ "$(printf '%s\n%s\n' "$old" "$new" | sort -V | tail -n1)" != "$new" ]]; then
+            echo "Error: new version $new is not greater than previous $old"
+            exit 1
+          fi
+
       - name: commit
+        if: steps.check.outputs.changed == 'true'
         uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20
         with:
           commit_message: "Release version '${{ env.TAG_NAME }}'"


### PR DESCRIPTION
Tested in these runs:

* [the workflow passes and does nothing if there are no git changes.](https://github.com/tomtom-international/tomtom-maps-mcp/actions/runs/25796856362)
* [the workflow fails if the provided version is not greater than the current version](https://github.com/tomtom-international/tomtom-maps-mcp/actions/runs/25796938475/job/75776514558)
