### PR TITLE
LSI-334 Route PRs to an environment so they can access the repo's secrets

### DIFF
--- a/.github/workflows/quality_checks.yml
+++ b/.github/workflows/quality_checks.yml
@@ -11,6 +11,7 @@ jobs:
   release:
     # Using the same Ubuntu version as in the Dockerfile for consistency
     runs-on: ubuntu-22.04
+    environment: ${{ github.event.pull_request.head.repo.fork && 'external-contrib' || 'internal-contrib' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Workflows run for PRs from forks don't have access to the repo's secrets by default. To give them access, we need to put the secrets in an environment and route the workflow to that environment.

I need to merge this PR to test it properly.