### PR TITLE
Remove unnecessary waits from search service tests

### DIFF
--- a/src/services/search/searchOrbisService.test.ts
+++ b/src/services/search/searchOrbisService.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   searchPlaces,
   poiSearch,
@@ -28,11 +28,6 @@ import type {
   GeocodingResponse,
   ReverseGeocodingResponse,
 } from "@tomtom-org/maps-sdk/services";
-
-beforeEach(async () => {
-  // TODO(LSI-52) Implement robust way of awaiting loading of dependencies.
-  await new Promise((resolve) => setTimeout(resolve, 500));
-});
 
 // Real tests using SDK — responses are GeoJSON FeatureCollections
 describe("Search SDK Service", () => {

--- a/src/services/search/searchService.test.ts
+++ b/src/services/search/searchService.test.ts
@@ -25,13 +25,6 @@ import {
 } from "./searchService";
 import type { POIResult, ReverseGeocodingResult } from "./types";
 
-import { beforeEach } from "vitest";
-
-beforeEach(async () => {
-  // TODO(LSI-52) Implement robust way of awaiting loading of dependencies.
-  await new Promise((resolve) => setTimeout(resolve, 500));
-});
-
 // Real test using actual API calls
 describe("Search Service", () => {
   it("should search for a city name (Amsterdam)", async () => {


### PR DESCRIPTION
## Description

This removes the `beforeEach` 500ms delay from the two search service test files:

- `src/services/search/searchService.test.ts`
- `src/services/search/searchOrbisService.test.ts`

I investigated the original TODO and did not find a search-specific dependency that needs explicit awaiting in these files.

I also ran both test files without the delay. The issues I observed were reproducible live API/permission failures (`403`), not dependency-loading failures.

If there is historical context behind LSI-52 that applies specifically to these search tests, I’m happy to update the approach.

Fixes: N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Ran the affected test files locally without the `beforeEach` wait:

```bash
cmd /c "npx vitest run src/services/search/searchService.test.ts"
cmd /c "npx vitest run src/services/search/searchOrbisService.test.ts"
```
Observed behavior:

- `searchService.test.ts`: the remaining failure was a reproducible `403` related to API request permissions/options, not dependency loading
- `searchOrbisService.test.ts`: the remaining failures were reproducible `403` responses from live Orbis geocode/reverse-geocode API calls, not dependency loading

- [x] Ran `searchService.test.ts` locally
- [x] Ran `searchOrbisService.test.ts` locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have signed-off my commits as per the DCO