### PR TITLE
LSI-31 Add MCP server instructions and trim tool descriptions

### DIFF
--- a/src/createServer.test.ts
+++ b/src/createServer.test.ts
@@ -57,6 +57,10 @@ vi.mock("./tools/dataVizOrbisTools", () => ({
 vi.mock("./services/base/tomtomClient", () => ({ validateApiKey: mockValidateApiKey, isHttpMode: false }));
 vi.mock("./utils/logger", () => ({ logger: mockLogger }));
 vi.mock("./version", () => ({ VERSION: "1.0.0-test" }));
+vi.mock("./instructions", () => ({
+  getServerInstructions: (isOrbis: boolean) =>
+    isOrbis ? "Orbis instructions" : "Standard instructions",
+}));
 
 const { createServer } = await import("./createServer");
 

--- a/src/createServer.ts
+++ b/src/createServer.ts
@@ -28,6 +28,7 @@ import { createRoutingOrbisTools } from "./tools/routingOrbisTools";
 import { createTrafficOrbisTools } from "./tools/trafficOrbisTools";
 import { createDataVizOrbisTools } from "./tools/dataVizOrbisTools";
 import { VERSION } from "./version";
+import { getServerInstructions } from "./instructions";
 
 /**
  * Configuration interface for server creation
@@ -77,10 +78,15 @@ export async function createServer(config?: ServerConfig): Promise<McpServer> {
     validateServerApiKey();
   }
 
-  const server = new McpServer({
-    name: serverName,
-    version: VERSION,
-  });
+  const server = new McpServer(
+    {
+      name: serverName,
+      version: VERSION,
+    },
+    {
+      instructions: getServerInstructions(isOrbis),
+    }
+  );
 
   // Note: Session-specific API key context is managed at the HTTP request level
   // using AsyncLocalStorage for proper isolation between concurrent sessions

--- a/src/indexHttp.integration.test.ts
+++ b/src/indexHttp.integration.test.ts
@@ -23,6 +23,17 @@ const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const TEST_API_KEY = "test-api-key";
 
+interface InitializeResponse {
+  jsonrpc: string;
+  id: number;
+  result?: {
+    protocolVersion: string;
+    capabilities: Record<string, unknown>;
+    serverInfo: { name: string; version: string };
+    instructions?: string;
+  };
+}
+
 interface ToolsListResponse {
   jsonrpc: string;
   id: number;
@@ -67,6 +78,39 @@ async function postMcpListTools({ port, backend }: { port: number; backend?: str
     headers,
     body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
   });
+}
+
+async function postMcpInitialize({ port, backend }: { port: number; backend?: string }) {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json,text/event-stream",
+    Connection: "close",
+    "tomtom-api-key": TEST_API_KEY,
+  };
+  if (backend != null) {
+    headers["tomtom-maps-backend"] = backend;
+  }
+
+  return await fetch(`http://localhost:${port}/${ENDPOINT_MCP}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "test-client", version: "1.0.0" },
+      },
+    }),
+  });
+}
+
+/** Helper to call initialize endpoint */
+async function initialize(port: number, backend?: string): Promise<InitializeResponse> {
+  const response = await postMcpInitialize({ port, backend });
+  return parseSSEResponse(await response.text());
 }
 
 /** Helper to call tools/list endpoint */
@@ -142,6 +186,28 @@ describe("HTTP Server Integration - Dual Backend Mode", () => {
   it("defaults to tomtom-orbis-maps when no header is provided", async () => {
     const result = await listTools(TEST_PORT);
     expectToolsToTargetBackend(result, "tomtom-orbis-maps");
+  });
+
+  it("initialize returns instructions for standard backend", async () => {
+    const result = await initialize(TEST_PORT, "tomtom-maps");
+
+    expect(result.result).toBeDefined();
+    expect(result.result!.instructions).toBeDefined();
+    expect(typeof result.result!.instructions).toBe("string");
+    expect(result.result!.instructions!.length).toBeGreaterThan(0);
+    expect(result.result!.instructions).toContain("tomtom-static-map");
+    expect(result.result!.instructions).not.toContain("tomtom-data-viz");
+  });
+
+  it("initialize returns instructions for Orbis backend", async () => {
+    const result = await initialize(TEST_PORT, "tomtom-orbis-maps");
+
+    expect(result.result).toBeDefined();
+    expect(result.result!.instructions).toBeDefined();
+    expect(typeof result.result!.instructions).toBe("string");
+    expect(result.result!.instructions!.length).toBeGreaterThan(0);
+    expect(result.result!.instructions).toContain("tomtom-data-viz");
+    expect(result.result!.instructions).not.toContain("tomtom-static-map");
   });
 
   it("returns TomTom-Upstream-Metadata response header with base64-encoded auth type for api key", async () => {

--- a/src/instructions.test.ts
+++ b/src/instructions.test.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2025 TomTom Navigation B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect } from "vitest";
+import { getServerInstructions } from "./instructions";
+
+describe("getServerInstructions", () => {
+  const standard = getServerInstructions(false);
+  const orbis = getServerInstructions(true);
+
+  it("should return non-empty strings for both backends", () => {
+    expect(standard.length).toBeGreaterThan(0);
+    expect(orbis.length).toBeGreaterThan(0);
+  });
+
+  it("should return different content for standard vs Orbis", () => {
+    expect(standard).not.toBe(orbis);
+  });
+
+  it("standard instructions should reference standard-only tools", () => {
+    expect(standard).toContain("tomtom-static-map");
+    expect(standard).toContain("tomtom-waypoint-routing");
+  });
+
+  it("standard instructions should NOT reference Orbis-exclusive tools", () => {
+    expect(standard).not.toContain("tomtom-ev-routing");
+    expect(standard).not.toContain("tomtom-data-viz");
+    expect(standard).not.toContain("tomtom-area-search");
+    expect(standard).not.toContain("tomtom-ev-search");
+    expect(standard).not.toContain("tomtom-search-along-route");
+    expect(standard).not.toContain("tomtom-poi-categories");
+  });
+
+  it("Orbis instructions should reference Orbis-exclusive tools", () => {
+    expect(orbis).toContain("tomtom-ev-routing");
+    expect(orbis).toContain("tomtom-data-viz");
+    expect(orbis).toContain("tomtom-area-search");
+    expect(orbis).toContain("tomtom-ev-search");
+    expect(orbis).toContain("tomtom-search-along-route");
+    expect(orbis).toContain("tomtom-poi-categories");
+  });
+
+  it("Orbis instructions should NOT reference standard-only tools", () => {
+    expect(orbis).not.toContain("tomtom-static-map");
+    expect(orbis).not.toContain("tomtom-waypoint-routing");
+  });
+
+  it("both instructions should reference shared tools", () => {
+    for (const instructions of [standard, orbis]) {
+      expect(instructions).toContain("tomtom-routing");
+      expect(instructions).toContain("tomtom-traffic");
+      expect(instructions).toContain("tomtom-dynamic-map");
+      expect(instructions).toContain("tomtom-geocode");
+      expect(instructions).toContain("tomtom-fuzzy-search");
+    }
+  });
+});
+
+describe("tool-instruction coherence", () => {
+  const standard = getServerInstructions(false);
+  const orbis = getServerInstructions(true);
+
+  const STANDARD_TOOLS = [
+    "tomtom-geocode",
+    "tomtom-reverse-geocode",
+    "tomtom-fuzzy-search",
+    "tomtom-poi-search",
+    "tomtom-nearby",
+    "tomtom-routing",
+    "tomtom-waypoint-routing",
+    "tomtom-reachable-range",
+    "tomtom-traffic",
+    "tomtom-static-map",
+    "tomtom-dynamic-map",
+  ];
+
+  const ORBIS_TOOLS = [
+    "tomtom-geocode",
+    "tomtom-reverse-geocode",
+    "tomtom-fuzzy-search",
+    "tomtom-poi-search",
+    "tomtom-nearby",
+    "tomtom-poi-categories",
+    "tomtom-area-search",
+    "tomtom-ev-search",
+    "tomtom-search-along-route",
+    "tomtom-routing",
+    "tomtom-reachable-range",
+    "tomtom-ev-routing",
+    "tomtom-traffic",
+    "tomtom-dynamic-map",
+    "tomtom-data-viz",
+  ];
+
+  it("standard instructions should reference every standard tool", () => {
+    for (const tool of STANDARD_TOOLS) {
+      expect(standard, `missing tool: ${tool}`).toContain(tool);
+    }
+  });
+
+  it("Orbis instructions should reference every Orbis tool", () => {
+    for (const tool of ORBIS_TOOLS) {
+      expect(orbis, `missing tool: ${tool}`).toContain(tool);
+    }
+  });
+});
+
+describe("LLM interpretation quality — keyword coverage", () => {
+  const standard = getServerInstructions(false);
+  const orbis = getServerInstructions(true);
+
+  const KEYWORD_CHECKS: Array<{
+    tool: string;
+    keywords: string[];
+    backends: ("standard" | "orbis")[];
+  }> = [
+    { tool: "tomtom-geocode", keywords: ["address", "coordinates"], backends: ["standard", "orbis"] },
+    { tool: "tomtom-reverse-geocode", keywords: ["coordinates", "address"], backends: ["standard", "orbis"] },
+    { tool: "tomtom-routing", keywords: ["route", "directions"], backends: ["standard", "orbis"] },
+    { tool: "tomtom-traffic", keywords: ["traffic", "incidents"], backends: ["standard", "orbis"] },
+    { tool: "tomtom-dynamic-map", keywords: ["markers", "polygons"], backends: ["standard", "orbis"] },
+    { tool: "tomtom-static-map", keywords: ["map"], backends: ["standard"] },
+    { tool: "tomtom-poi-search", keywords: ["POI", "business"], backends: ["standard", "orbis"] },
+    { tool: "tomtom-nearby", keywords: ["nearby", "near"], backends: ["standard", "orbis"] },
+    { tool: "tomtom-fuzzy-search", keywords: ["search", "typo"], backends: ["standard", "orbis"] },
+    { tool: "tomtom-reachable-range", keywords: ["reachable", "range"], backends: ["standard", "orbis"] },
+    { tool: "tomtom-waypoint-routing", keywords: ["waypoint", "multi-stop", "3+"], backends: ["standard"] },
+    { tool: "tomtom-poi-categories", keywords: ["category", "UPPER_SNAKE_CASE"], backends: ["orbis"] },
+    { tool: "tomtom-area-search", keywords: ["boundary", "polygon"], backends: ["orbis"] },
+    { tool: "tomtom-ev-search", keywords: ["EV", "charging"], backends: ["orbis"] },
+    { tool: "tomtom-ev-routing", keywords: ["EV", "charging"], backends: ["orbis"] },
+    { tool: "tomtom-search-along-route", keywords: ["along", "route"], backends: ["orbis"] },
+    { tool: "tomtom-data-viz", keywords: ["heatmap", "GeoJSON", "choropleth"], backends: ["orbis"] },
+  ];
+
+  for (const { tool, keywords, backends } of KEYWORD_CHECKS) {
+    for (const backend of backends) {
+      it(`${tool} (${backend}) — instructions contain at least one keyword: [${keywords.join(", ")}]`, () => {
+        const instructions = backend === "standard" ? standard : orbis;
+        const found = keywords.some((kw) => instructions.toLowerCase().includes(kw.toLowerCase()));
+        expect(found, `${tool}: none of [${keywords.join(", ")}] found in ${backend} instructions`).toBe(
+          true
+        );
+      });
+    }
+  }
+});

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025 TomTom Navigation B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const STANDARD_INSTRUCTIONS = `TomTom Maps MCP Server — geocoding, search, routing, traffic, and map visualization.
+
+Tool selection:
+- Directions/routes/travel time → tomtom-routing (A-to-B) or tomtom-waypoint-routing (3+ stops)
+- Reachable area within time/distance budget → tomtom-reachable-range
+- Traffic/accidents/congestion → tomtom-traffic (not tomtom-dynamic-map)
+- Map with markers/routes/polygons → tomtom-dynamic-map
+- Simple map image → tomtom-static-map
+- Address to coordinates → tomtom-geocode (addresses only, not POIs)
+- Coordinates to address → tomtom-reverse-geocode
+- Vague or typo-tolerant query → tomtom-fuzzy-search
+- POI by name or category → tomtom-poi-search
+- Places near a point → tomtom-nearby
+
+Guidelines:
+- Geocode place names to coordinates before using routing or traffic tools.
+- Use response_detail="compact" (default) to save tokens; use "full" only when detailed data is needed.`;
+
+const ORBIS_INSTRUCTIONS = `TomTom Orbis Maps MCP Server — geocoding, search, routing, traffic, map visualization, and data visualization.
+
+Tool selection:
+- Directions/routes/travel time (A-to-B or multi-stop) → tomtom-routing
+- EV long-distance routes with charging stops → tomtom-ev-routing
+- Reachable area within time/distance budget → tomtom-reachable-range
+- Traffic/accidents/congestion → tomtom-traffic (not tomtom-dynamic-map)
+- Map with markers/routes/polygons → tomtom-dynamic-map
+- Large datasets/heatmaps/clusters/choropleth → tomtom-data-viz (not tomtom-dynamic-map)
+- Address to coordinates → tomtom-geocode (addresses only, not POIs)
+- Coordinates to address → tomtom-reverse-geocode
+- Vague or typo-tolerant query → tomtom-fuzzy-search
+- POI by name or category → tomtom-poi-search (location bias, not strict boundary)
+- Places near a point → tomtom-nearby (radius)
+- POIs within a strict boundary → tomtom-area-search (polygon/bbox/circle)
+- POIs along a driving route → tomtom-search-along-route
+- EV charging stations → tomtom-ev-search
+- POI category codes → tomtom-poi-categories (required before using poiCategories filters; never guess codes)
+
+Guidelines:
+- Geocode place names to coordinates before using routing or traffic tools.
+- Use response_detail="compact" (default) to save tokens; use "full" only when detailed data is needed.`;
+
+export function getServerInstructions(isOrbis: boolean): string {
+  return isOrbis ? ORBIS_INSTRUCTIONS : STANDARD_INSTRUCTIONS;
+}

--- a/src/tools/dataVizOrbisTools.ts
+++ b/src/tools/dataVizOrbisTools.ts
@@ -39,13 +39,9 @@ export async function createDataVizOrbisTools(server: McpServer): Promise<void> 
     {
       title: "TomTom Data Visualization",
       description:
-        "Visualize custom GeoJSON data on an interactive TomTom basemap. " +
-        "Use this for LARGE DATASETS, heatmaps, cluster maps, choropleth maps, or when you have GeoJSON data (from a URL or inline) to render on a map. " +
+        "Visualize custom GeoJSON data on a TomTom basemap. " +
         "Supports markers, heatmaps, clusters, lines, polygon fills, and choropleth maps. " +
-        "Provide data via HTTPS URL or inline GeoJSON. Multiple layers can be overlaid in a single call. " +
-        "Point features are automatically enriched with TomTom address data when clicked (reverse geocode). " +
-        "For placing a few specific markers, routes, or polygons, use tomtom-dynamic-map instead. " +
-        "For route calculations (directions, travel time), use tomtom-routing.",
+        "Provide data via HTTPS URL or inline GeoJSON. Multiple layers can be overlaid in a single call.",
       inputSchema: tomtomDataVizSchema,
       annotations: {
         title: "TomTom Data Visualization",

--- a/src/tools/mapOrbisTools.ts
+++ b/src/tools/mapOrbisTools.ts
@@ -40,10 +40,8 @@ export async function createMapOrbisTools(server: McpServer): Promise<void> {
     {
       title: "TomTom Dynamic Map",
       description:
-        "Render a custom map image with markers, drawn lines, polygons, and area overlays — with interactive map UI. " +
-        "Use this for MAP VISUALIZATION: showing locations on a map, highlighting areas, or combining multiple visual elements in one view. " +
-        "Do NOT use this for: route calculations (use tomtom-routing), traffic incidents (use tomtom-traffic), or large-dataset visualization like heatmaps/clusters/choropleth (use tomtom-data-viz). " +
-        "The optional routePlans parameter can calculate and draw routes on the map, but only use it when you need routes combined with other map elements (markers, polygons) in a single image.",
+        "Render a map with markers, lines, polygons, and area overlays. " +
+        "Supports an optional routePlans parameter to draw routes on the map.",
       inputSchema: schemas.tomtomDynamicMapSchema,
       annotations: {
         title: "TomTom Dynamic Map",

--- a/src/tools/mapTools.test.ts
+++ b/src/tools/mapTools.test.ts
@@ -50,7 +50,7 @@ describe("createMapTools", () => {
       "tomtom-dynamic-map",
       expect.objectContaining({
         title: "TomTom Dynamic Map",
-        description: expect.stringContaining("MAP VISUALIZATION"),
+        description: expect.stringContaining("markers, drawn lines, polygons"),
         inputSchema: expect.any(Object),
       }),
       expect.any(Function)

--- a/src/tools/mapTools.ts
+++ b/src/tools/mapTools.ts
@@ -51,9 +51,7 @@ export function createMapTools(server: McpServer): void {
       title: "TomTom Dynamic Map",
       description:
         "Render a custom map image with markers, drawn lines, polygons, and area overlays using server-side rendering. " +
-        "Use this for MAP VISUALIZATION: showing locations on a map, highlighting areas, or combining multiple visual elements in one view. " +
-        "Do NOT use this for: route calculations (use tomtom-routing), or traffic incidents (use tomtom-traffic). " +
-        "The optional routePlans parameter can calculate and draw routes on the map, but only use it when you need routes combined with other map elements (markers, polygons) in a single image.",
+        "Supports an optional routePlans parameter to draw routes on the map.",
       inputSchema: schemas.tomtomDynamicMapSchema,
       annotations: {
         title: "TomTom Dynamic Map",

--- a/src/tools/routingOrbisTools.ts
+++ b/src/tools/routingOrbisTools.ts
@@ -50,7 +50,7 @@ export async function createRoutingOrbisTools(server: McpServer): Promise<void> 
     {
       title: "TomTom Routing",
       description:
-        "Calculate optimal routes through an ordered list of locations [origin, ...stops, destination]. Use this tool FIRST when the user asks about directions, routes, travel time, or distance between places — whether it's a simple A-to-B or a multi-stop itinerary (e.g. 'route from Amsterdam to Berlin', 'drive from A to B via C and D'). Returns turn-by-turn directions, distance, travel time, and an interactive map. For visualizing multiple routes or combining routes with markers/polygons on a single map image, use tomtom-dynamic-map.",
+        "Calculate optimal routes through an ordered list of locations [origin, ...stops, destination]. Supports simple A-to-B and multi-stop itineraries. Returns turn-by-turn directions, distance, and travel time.",
       inputSchema: schemas.tomtomRoutingSchema,
       annotations: {
         title: "TomTom Routing",
@@ -74,7 +74,7 @@ export async function createRoutingOrbisTools(server: McpServer): Promise<void> 
     {
       title: "TomTom Reachable Range",
       description:
-        "Determine the area reachable within a specified time or driving distance with interactive map UI",
+        "Determine the area reachable within a specified time or driving distance",
       inputSchema: schemas.tomtomReachableRangeSchema,
       annotations: {
         title: "TomTom Reachable Range",
@@ -99,7 +99,7 @@ export async function createRoutingOrbisTools(server: McpServer): Promise<void> 
     {
       title: "TomTom EV Route Planner",
       description:
-        "Plan long-distance electric vehicle routes with automatic charging stop optimization. Calculates optimal charging stops based on battery state, vehicle model, and charging connector compatibility. Uses TomTom Maps SDK.",
+        "Plan long-distance EV routes with automatic charging stop optimization based on battery state, vehicle model, and connector compatibility.",
       inputSchema: schemas.tomtomEvRoutingSchema,
       annotations: {
         title: "TomTom EV Route Planner",

--- a/src/tools/routingTools.ts
+++ b/src/tools/routingTools.ts
@@ -33,7 +33,7 @@ export function createRoutingTools(server: McpServer): void {
     {
       title: "TomTom Routing",
       description:
-        "Calculate optimal routes between two locations. Use this tool FIRST when the user asks about directions, routes, travel time, or distance between places (e.g. 'route from Amsterdam to Berlin', 'how long to drive from A to B'). Returns turn-by-turn directions, distance, travel time, and a map image. For multi-stop routes with 3+ waypoints, use tomtom-waypoint-routing instead. For visualizing multiple routes or combining routes with markers/polygons on a single map image, use tomtom-dynamic-map.",
+        "Calculate optimal routes between two locations. Returns turn-by-turn directions, distance, travel time, and a map image.",
       inputSchema: schemas.tomtomRoutingSchema,
       annotations: {
         title: "TomTom Routing",
@@ -53,7 +53,7 @@ export function createRoutingTools(server: McpServer): void {
     {
       title: "TomTom Waypoint Routing",
       description:
-        "Plan multi-stop routes through 3 or more waypoints. Use when the user needs to visit multiple locations in sequence (e.g. 'route from A to B via C and D'). Returns optimized turn-by-turn directions, total distance, and travel time. For simple A-to-B routes, use tomtom-routing instead.",
+        "Plan multi-stop routes through 3 or more ordered waypoints. Returns turn-by-turn directions, total distance, and travel time.",
       inputSchema: schemas.tomtomWaypointRoutingSchema,
       annotations: {
         title: "TomTom Waypoint Routing",

--- a/src/tools/searchOrbisTools.ts
+++ b/src/tools/searchOrbisTools.ts
@@ -70,7 +70,7 @@ export async function createSearchOrbisTools(server: McpServer): Promise<void> {
     "tomtom-geocode",
     {
       title: "TomTom Geocode",
-      description: "Convert street addresses to coordinates with interactive map UI",
+      description: "Convert street addresses to coordinates (does not support POI names)",
       inputSchema: schemas.tomtomGeocodeSearchSchema,
       annotations: {
         title: "TomTom Geocode",
@@ -93,7 +93,7 @@ export async function createSearchOrbisTools(server: McpServer): Promise<void> {
     "tomtom-reverse-geocode",
     {
       title: "TomTom Reverse Geocode",
-      description: "Convert coordinates to addresses with interactive map UI",
+      description: "Convert coordinates to addresses",
       inputSchema: schemas.tomtomReverseGeocodeSearchSchema,
       annotations: {
         title: "TomTom Reverse Geocode",
@@ -117,7 +117,7 @@ export async function createSearchOrbisTools(server: McpServer): Promise<void> {
     {
       title: "TomTom Fuzzy Search",
       description:
-        "Typo-tolerant search for addresses, points of interest, and geographies with interactive map UI",
+        "Typo-tolerant search for addresses, points of interest, and geographies",
       inputSchema: schemas.tomtomFuzzySearchSchema,
       annotations: {
         title: "TomTom Fuzzy Search",
@@ -141,7 +141,7 @@ export async function createSearchOrbisTools(server: McpServer): Promise<void> {
     {
       title: "TomTom POI Search",
       description:
-        "Search for a specific business or POI by name, or browse an entire POI category. Best for finding a known place (e.g. 'Starbucks') or listing all businesses of a type (e.g. category 7315 for restaurants). Supports optional location bias but does NOT constrain results to a strict geographic boundary — use tomtom-area-search for that.",
+        "Search for a specific business or POI by name, or browse an entire POI category. Supports optional location bias.",
       inputSchema: schemas.tomtomPOISearchSchema,
       annotations: {
         title: "TomTom POI Search",
@@ -164,8 +164,7 @@ export async function createSearchOrbisTools(server: McpServer): Promise<void> {
     "tomtom-nearby",
     {
       title: "TomTom Nearby Search",
-      description:
-        "Find places close to a specific point. Best for 'what's around here?' queries when you have exact coordinates (lat/lon). Returns results sorted by distance. Use tomtom-area-search instead when the search area is a polygon or bounding box rather than a simple radius.",
+      description: "Find places close to a specific point, sorted by distance.",
       inputSchema: schemas.tomtomNearbySearchSchema,
       annotations: {
         title: "TomTom Nearby Search",
@@ -189,12 +188,11 @@ export async function createSearchOrbisTools(server: McpServer): Promise<void> {
     {
       title: "TomTom POI Categories",
       description:
-        "Look up POI category codes from natural language. REQUIRED before using poiCategories in any search tool. " +
+        "Look up POI category codes from natural language. " +
         "Category codes are UPPER_SNAKE_CASE text strings (e.g. 'ITALIAN_RESTAURANT', 'PARKING_GARAGE'), NOT numeric IDs. " +
-        "Workflow: (1) Extract the user's intent as keywords (e.g. user asks 'italian restaurants in Amsterdam' → filters: ['italian restaurant']). " +
+        "Workflow: (1) Extract the user's intent as keywords (e.g. 'italian restaurant'). " +
         "(2) Call this tool with those keywords in the filters parameter. " +
-        "(3) Use the returned text category codes in the poiCategories parameter of search tools (fuzzy-search, poi-search, nearby, area-search). " +
-        "Never guess or hardcode category codes — always discover them through this tool first.",
+        "(3) Use the returned codes in the poiCategories parameter of search tools.",
       inputSchema: schemas.tomtomPOICategoriesSchema,
       annotations: {
         title: "TomTom POI Categories",
@@ -219,7 +217,7 @@ export async function createSearchOrbisTools(server: McpServer): Promise<void> {
     {
       title: "TomTom Area Search",
       description:
-        "Find all POIs within a strict geographic boundary — polygon, bounding box, or circle. Use this when the search must be confined to a specific region (e.g. 'restaurants inside Westminster', 'hotels within this polygon'). Unlike tomtom-nearby (radius from a point) or tomtom-poi-search (location bias), this tool guarantees results are inside the defined geometry.",
+        "Find all POIs within a strict geographic boundary — polygon, bounding box, or circle. Guarantees results are inside the defined geometry.",
       inputSchema: schemas.tomtomAreaSearchSchema,
       annotations: {
         title: "TomTom Area Search",
@@ -244,7 +242,7 @@ export async function createSearchOrbisTools(server: McpServer): Promise<void> {
     {
       title: "TomTom EV Charging Search",
       description:
-        "Find EV charging stations with real-time availability, connector types, and power levels. Uses TomTom Maps SDK for enriched results with charger status (available/occupied/out-of-service).",
+        "Find EV charging stations with real-time availability, connector types, and power levels.",
       inputSchema: schemas.tomtomEvSearchSchema,
       annotations: {
         title: "TomTom EV Charging Search",
@@ -274,7 +272,7 @@ export async function createSearchOrbisTools(server: McpServer): Promise<void> {
     {
       title: "TomTom Search Along Route",
       description:
-        "Find points of interest (restaurants, gas stations, hotels, etc.) along a route corridor. Calculates the route between origin and destination, then searches for POIs within a configurable distance from the route. Uses TomTom Maps SDK.",
+        "Find points of interest along a route corridor between origin and destination.",
       inputSchema: schemas.tomtomSearchAlongRouteSchema,
       annotations: {
         title: "TomTom Search Along Route",

--- a/src/tools/trafficOrbisTools.ts
+++ b/src/tools/trafficOrbisTools.ts
@@ -38,9 +38,7 @@ export async function createTrafficOrbisTools(server: McpServer): Promise<void> 
     {
       title: "TomTom Traffic",
       description:
-        "Find and display traffic incidents in an area on an interactive map. Use this tool FIRST when the user asks about traffic, accidents, road closures, congestion, or dangerous road conditions. " +
-        "Incidents are rendered as styled icons on the map and can be clicked for details (severity, description, delay, road name). " +
-        "Do NOT use tomtom-dynamic-map to plot traffic incidents as markers — this tool already provides a complete interactive traffic visualization.",
+        "Find and display traffic incidents in an area. Returns incident data with severity, description, delay, and road details.",
       inputSchema: schemas.tomtomTrafficSchema,
       annotations: {
         title: "TomTom Traffic",

--- a/src/tools/trafficTools.ts
+++ b/src/tools/trafficTools.ts
@@ -28,9 +28,7 @@ export function createTrafficTools(server: McpServer): void {
     {
       title: "TomTom Traffic",
       description:
-        "Find and display traffic incidents in an area. Use this tool FIRST when the user asks about traffic, accidents, road closures, congestion, or dangerous road conditions. " +
-        "Returns detailed incident data including severity, description, delay, and affected roads. " +
-        "Do NOT use tomtom-dynamic-map to plot traffic incidents as markers — this tool provides complete traffic incident data.",
+        "Find and display traffic incidents in an area. Returns incident data including severity, description, delay, and affected roads.",
       inputSchema: schemas.tomtomTrafficSchema,
       annotations: {
         title: "TomTom Traffic",


### PR DESCRIPTION
## Summary

- **Add MCP server-level `instructions`** — backend-specific tool selection decision trees sent to AI clients during initialization, helping LLMs choose the right tool for each query
- **Trim tool descriptions** — remove cross-cutting guidance (11 "Do NOT use X" patterns, 4 "Use FIRST when..." patterns, 9× "with interactive map UI") that now lives in server instructions
- **Net result**: ~17% reduction in total description+instruction text while improving tool selection clarity

## Details

The MCP protocol supports an `instructions` field in the server init response. We now use it to consolidate duplicated cross-tool guidance into a centralized decision tree, while slimming individual tool descriptions to focus on what each tool does (not when to pick it over alternatives).

### New files
- `src/instructions.ts` — `getServerInstructions(isOrbis)` with backend-specific instructions
- `src/instructions.test.ts` — 35 tests covering content correctness, tool-instruction coherence, and keyword coverage

### Modified files
- `src/createServer.ts` — passes instructions to McpServer constructor
- 9 tool files — trimmed descriptions (routing, traffic, map, search, dataViz for both backends)
- `src/indexHttp.integration.test.ts` — 2 new tests verifying initialize response includes instructions
- `src/createServer.test.ts` — added instructions mock
- `src/tools/mapTools.test.ts` — updated description assertion

## Test plan

- [x] 35 unit tests: content correctness, backend exclusivity, tool-instruction coherence (every registered tool referenced in instructions), LLM keyword coverage
- [x] 13 HTTP integration tests: 2 new tests verify `initialize` response contains backend-specific instructions for both standard and Orbis
- [x] 26 existing tool/server unit tests still pass
- [x] Build succeeds
- [x] Lint: 0 errors
- [ ] Manual: connect from Claude Desktop/Cursor and verify tool selection with representative prompts