### PR TITLE
LSI-477 Automatically bump NPM dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      # The cooldown reduces the risk of updating a dependency to a version with a still unknown
+      # security vulnerability.
+      default-days: 7
+      # Exclude internal dependencies from the cooldown; we want to discover issues ASAP.
+      exclude:
+        - "@tomtom-org/maps-sdk"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+    pull-request-branch-name:
+      # Separate sections of the branch name with a hyphen
+      # for example, `dependabot-npm_and_yarn-next_js-acorn-6.4.1`
+      separator: "-"


### PR DESCRIPTION
To test this I need to merge it into `main`.

My initial idea was to set up Dependabot to only automatically update @tomtom-org/maps-sdk, but this wasn’t possible as it would turn off security updates for all other dependencies. So I decided to set up Dependabot to just update all dependencies every week. Except for maps-sdk, all new versions have a cooldown of one week to prevent updating to versions with unknown security vulnerabilities.