### PR TITLE
feat: upgrade to latest sdk with orbis routing ga api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@rollup/plugin-typescript": "^12.3.0",
-        "@tomtom-org/maps-sdk": "^0.48.0",
+        "@tomtom-org/maps-sdk": "^0.48.3",
         "@turf/buffer": "^7.3.4",
         "@types/pako": "^2.0.4",
         "axios": "^1.13.6",
@@ -3239,9 +3239,9 @@
       "license": "MIT"
     },
     "node_modules/@tomtom-org/maps-sdk": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@tomtom-org/maps-sdk/-/maps-sdk-0.48.0.tgz",
-      "integrity": "sha512-wSXAhny3rj9FaI15OUsBgBfSBUhX+UbbIwDp4fVwQ0+eQ98Pz7tZQbxy9LiCBpA/Kz1kqJTaVfkBzMyRPtsnfA==",
+      "version": "0.48.3",
+      "resolved": "https://registry.npmjs.org/@tomtom-org/maps-sdk/-/maps-sdk-0.48.3.tgz",
+      "integrity": "sha512-9rmR5xihcWr5UZgzkRQdTLz6QqpUWg1LZ5qMt9cxcGlYadd5o06wMw4r/ndFoTuGatCDr5ujHNtAlQ2M/+plug==",
       "hasInstallScript": true,
       "license": "See in LICENSE.txt",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-typescript": "^12.3.0",
-    "@tomtom-org/maps-sdk": "^0.48.0",
+    "@tomtom-org/maps-sdk": "^0.48.3",
     "@turf/buffer": "^7.3.4",
     "@types/pako": "^2.0.4",
     "axios": "^1.13.6",


### PR DESCRIPTION
## Description

Upgrades `@tomtom-org/maps-sdk` from `^0.48.0` to `^0.48.3`, which brings in the **Orbis Routing GA** API. This updates both `package.json` and `package-lock.json`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] `npm ci` / install resolves the updated lockfile cleanly
- [x] Existing unit tests pass locally with the upgraded SDK

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have signed-off my commits as per the DCO
