### PR TITLE
Fix Anthropic MCP directory review findings (data-viz data_url, traffic cap, ev-search metadata)

### DIFF
--- a/src/handlers/dataVizOrbisHandler.test.ts
+++ b/src/handlers/dataVizOrbisHandler.test.ts
@@ -163,6 +163,43 @@ describe("createDataVizHandler", () => {
       expect(result.summary.feature_count).toBe(1);
     });
 
+    it("DNS-pinning lookup handles the all:true option (Node 20+ autoSelectFamily)", async () => {
+      mockLookup.mockResolvedValue({ address: "93.184.216.34", family: 4 });
+      mockAxiosGet.mockResolvedValue({
+        data: {
+          type: "FeatureCollection",
+          features: [makePointFeature(4.89, 52.37)],
+        },
+      });
+
+      const handler = createDataVizHandler();
+      await handler({ data_url: "https://example.com/data.geojson", layers: defaultLayers });
+
+      const config = mockAxiosGet.mock.calls[0][1] as {
+        httpsAgent: { options: { lookup: (...args: unknown[]) => void } };
+      };
+      const pinnedLookup = config.httpsAgent.options.lookup;
+
+      // Plain form: callback(err, address, family)
+      let plainCalled = false;
+      pinnedLookup("example.com", {}, (err: unknown, address: unknown, family: unknown) => {
+        plainCalled = true;
+        expect(err).toBeNull();
+        expect(address).toBe("93.184.216.34");
+        expect(family).toBe(4);
+      });
+      expect(plainCalled).toBe(true);
+
+      // Happy Eyeballs form: callback(err, [{ address, family }])
+      let allCalled = false;
+      pinnedLookup("example.com", { all: true }, (err: unknown, addresses: unknown) => {
+        allCalled = true;
+        expect(err).toBeNull();
+        expect(addresses).toEqual([{ address: "93.184.216.34", family: 4 }]);
+      });
+      expect(allCalled).toBe(true);
+    });
+
     it("should include multiple layers in layers_applied", async () => {
       const geojson = makeFeatureCollection([makePointFeature(4.89, 52.37)]);
 

--- a/src/handlers/dataVizOrbisHandler.ts
+++ b/src/handlers/dataVizOrbisHandler.ts
@@ -216,11 +216,19 @@ async function validateUrl(url: string): Promise<string> {
 async function fetchGeoJSON(url: string): Promise<unknown> {
   const resolvedIp = await validateUrl(url);
 
-  // Pin DNS to the validated IP to prevent DNS rebinding
+  // Pin DNS to the validated IP to prevent DNS rebinding.
+  // Node 20+ enables autoSelectFamily (Happy Eyeballs) by default, which calls
+  // lookup with { all: true } and expects an array of { address, family }
+  // entries — answering with a plain string there makes net read
+  // addresses[0].address as undefined ("Invalid IP address: undefined").
   const agent = new https.Agent({
-    lookup: (_hostname, _options, callback) => {
+    lookup: (_hostname, options, callback) => {
       const family = isIP(resolvedIp) === 6 ? 6 : 4;
-      callback(null, resolvedIp, family);
+      if (options.all) {
+        callback(null, [{ address: resolvedIp, family }]);
+      } else {
+        callback(null, resolvedIp, family);
+      }
     },
   });
 

--- a/src/handlers/shared/responseTrimmer.test.ts
+++ b/src/handlers/shared/responseTrimmer.test.ts
@@ -21,6 +21,8 @@ import {
   trimTrafficResponse,
   trimReachableRangeResponse,
   buildCompressedResponse,
+  capTrafficIncidents,
+  DEFAULT_MAX_TRAFFIC_INCIDENTS,
 } from "./responseTrimmer";
 
 type TrimmedRoute = {
@@ -460,6 +462,71 @@ describe("trimTrafficResponse", () => {
     const response = { error: "No incidents found" };
     const trimmed = trimTrafficResponse(response);
     expect(trimmed).toEqual(response);
+  });
+});
+
+describe("capTrafficIncidents", () => {
+  type CappedTraffic = TrimmedTraffic & {
+    incidentSummary?: {
+      totalIncidents: number;
+      returnedIncidents: number;
+      truncated: boolean;
+      incidentsByIconCategory: Record<string, number>;
+      note: string;
+    };
+  };
+
+  const makeIncident = (id: string, magnitudeOfDelay: number, iconCategory = 6) => ({
+    type: "Feature",
+    properties: { id, magnitudeOfDelay, iconCategory },
+  });
+
+  it("should return the response unchanged when at or under the cap", () => {
+    const response = {
+      incidents: Array.from({ length: 10 }, (_, i) => makeIncident(`inc-${i}`, 1)),
+    };
+    const capped = capTrafficIncidents(response) as CappedTraffic;
+    expect(capped.incidents).toHaveLength(10);
+    expect(capped.incidentSummary).toBeUndefined();
+    expect(capped).toBe(response);
+  });
+
+  it("should keep the most severe incidents and add a summary when over the cap", () => {
+    const incidents = [
+      ...Array.from({ length: DEFAULT_MAX_TRAFFIC_INCIDENTS }, (_, i) =>
+        makeIncident(`minor-${i}`, 1, 6)
+      ),
+      makeIncident("closure", 4, 8),
+      makeIncident("major", 3, 1),
+    ];
+    const capped = capTrafficIncidents({ incidents }) as CappedTraffic;
+
+    expect(capped.incidents).toHaveLength(DEFAULT_MAX_TRAFFIC_INCIDENTS);
+    // Most severe incidents survive the cut
+    expect(capped.incidents![0].properties!.id).toBe("closure");
+    expect(capped.incidents![1].properties!.id).toBe("major");
+
+    expect(capped.incidentSummary).toEqual({
+      totalIncidents: DEFAULT_MAX_TRAFFIC_INCIDENTS + 2,
+      returnedIncidents: DEFAULT_MAX_TRAFFIC_INCIDENTS,
+      truncated: true,
+      incidentsByIconCategory: { "6": DEFAULT_MAX_TRAFFIC_INCIDENTS, "8": 1, "1": 1 },
+      note: expect.stringContaining(`of ${DEFAULT_MAX_TRAFFIC_INCIDENTS + 2} incidents`),
+    });
+  });
+
+  it("should respect a caller-provided maxIncidents", () => {
+    const incidents = Array.from({ length: 30 }, (_, i) => makeIncident(`inc-${i}`, i % 5));
+    const capped = capTrafficIncidents({ incidents }, 10) as CappedTraffic;
+
+    expect(capped.incidents).toHaveLength(10);
+    expect(capped.incidentSummary!.totalIncidents).toBe(30);
+    expect(capped.incidentSummary!.returnedIncidents).toBe(10);
+  });
+
+  it("should return the response unchanged when incidents are missing", () => {
+    const response = { error: "No incidents found" };
+    expect(capTrafficIncidents(response)).toBe(response);
   });
 });
 

--- a/src/handlers/shared/responseTrimmer.ts
+++ b/src/handlers/shared/responseTrimmer.ts
@@ -465,6 +465,58 @@ export function trimTrafficResponse(response: unknown, _backend?: Backend): unkn
   return trimmed;
 }
 
+/** Default maximum incidents returned to the agent (large bboxes can return thousands). */
+export const DEFAULT_MAX_TRAFFIC_INCIDENTS = 100;
+
+/**
+ * Cap the number of traffic incidents returned to the agent.
+ *
+ * Large bounding boxes can return thousands of incidents (hundreds of KB even
+ * after field trimming), overflowing client context limits. When the response
+ * exceeds the cap, the most severe incidents (by magnitudeOfDelay) are kept and
+ * an `incidentSummary` records the full totals so the agent knows the response
+ * was truncated.
+ */
+export function capTrafficIncidents(
+  response: unknown,
+  maxIncidents: number = DEFAULT_MAX_TRAFFIC_INCIDENTS
+): unknown {
+  const resp = response as TrafficResponse;
+  if (!resp?.incidents || resp.incidents.length <= maxIncidents) {
+    return response;
+  }
+
+  const total = resp.incidents.length;
+  const byCategory: Record<string, number> = {};
+  for (const incident of resp.incidents) {
+    const category = incident.properties?.iconCategory;
+    const key = category === undefined || category === null ? "unknown" : String(category);
+    byCategory[key] = (byCategory[key] ?? 0) + 1;
+  }
+
+  const kept = [...resp.incidents]
+    .sort(
+      (a, b) =>
+        (Number(b.properties?.magnitudeOfDelay) || 0) -
+        (Number(a.properties?.magnitudeOfDelay) || 0)
+    )
+    .slice(0, maxIncidents);
+
+  return {
+    ...resp,
+    incidents: kept,
+    incidentSummary: {
+      totalIncidents: total,
+      returnedIncidents: kept.length,
+      truncated: true,
+      incidentsByIconCategory: byCategory,
+      note:
+        `Showing the ${kept.length} most severe of ${total} incidents. ` +
+        `Narrow the bbox, use categoryFilter, or raise maxResults for more.`,
+    },
+  };
+}
+
 /**
  * Trim reachable range response - removes boundary coordinates.
  *

--- a/src/handlers/trafficHandler.ts
+++ b/src/handlers/trafficHandler.ts
@@ -16,7 +16,7 @@
 
 import { getTrafficIncidents } from "../services/traffic/trafficService";
 import { logger } from "../utils/logger";
-import { trimTrafficResponse, Backend } from "./shared/responseTrimmer";
+import { trimTrafficResponse, capTrafficIncidents, Backend } from "./shared/responseTrimmer";
 import type { TrafficIncidentsOptions } from "../services/traffic/types";
 import type { TrafficParams } from "../schemas/traffic/trafficSchema";
 
@@ -59,12 +59,15 @@ export function createTrafficHandler() {
       logger.info({ bbox }, "Traffic lookup");
       const result = await getTrafficByBbox(bbox, options);
 
+      // Cap incident count so large bboxes can't overflow client context limits
+      const capped = capTrafficIncidents(result, maxResults);
+
       // If full response requested, return without trimming
       if (response_detail === "full") {
-        return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+        return { content: [{ type: "text" as const, text: JSON.stringify(capped, null, 2) }] };
       }
 
-      const trimmed = trimTrafficResponse(result, BACKEND);
+      const trimmed = trimTrafficResponse(capped, BACKEND);
       return { content: [{ type: "text" as const, text: JSON.stringify(trimmed, null, 2) }] };
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);

--- a/src/handlers/trafficOrbisHandler.ts
+++ b/src/handlers/trafficOrbisHandler.ts
@@ -17,7 +17,12 @@
 import { getTrafficIncidents } from "../services/traffic/trafficOrbisService";
 import { logger } from "../utils/logger";
 import { handleApiError } from "../utils/apiErrorHandler";
-import { trimTrafficResponse, buildCompressedResponse, Backend } from "./shared/responseTrimmer";
+import {
+  trimTrafficResponse,
+  capTrafficIncidents,
+  buildCompressedResponse,
+  Backend,
+} from "./shared/responseTrimmer";
 import type { BBox } from "@tomtom-org/maps-sdk/core";
 import type { TrafficOrbisParams } from "../schemas/traffic/trafficOrbisSchema";
 
@@ -47,6 +52,7 @@ export function createTrafficHandler() {
         language: trafficParams.language,
         categoryFilter: trafficParams.categoryFilter,
         timeValidityFilter: trafficParams.timeValidityFilter,
+        maxResults: trafficParams.maxResults,
       };
 
       logger.info({ bbox: trafficParams.bbox }, "🚦 Traffic lookup");
@@ -55,14 +61,17 @@ export function createTrafficHandler() {
       const count = result.incidents?.length || 0;
       logger.info({ count }, "✅ Traffic incidents found");
 
+      // Cap agent-facing incidents; the uncapped result is still cached for the map UI
+      const capped = capTrafficIncidents(result, trafficParams.maxResults);
+
       // If full response requested, return without trimming (single content)
       if (response_detail === "full") {
-        const response = { ...result, _meta: { show_ui } };
+        const response = { ...(capped as object), _meta: { show_ui } };
         return { content: [{ type: "text" as const, text: JSON.stringify(response, null, 2) }] };
       }
 
       // Trimmed for agent, full data cached for Apps
-      const trimmed = trimTrafficResponse(result, BACKEND);
+      const trimmed = trimTrafficResponse(capped, BACKEND);
       return await buildCompressedResponse(trimmed, result, show_ui);
     } catch (error: unknown) {
       const formattedError = handleApiError(error, "Traffic lookup (Orbis)");

--- a/src/schemas/traffic/trafficOrbisSchema.ts
+++ b/src/schemas/traffic/trafficOrbisSchema.ts
@@ -62,6 +62,16 @@ export const tomtomTrafficSchema = {
       "Filter incidents by occurrence time. Values: 'present' (current incidents), 'future' (planned incidents). Multiple values comma-separated. Default: 'present'."
     ),
 
+  maxResults: z
+    .number()
+    .min(1)
+    .max(1000)
+    .optional()
+    .describe(
+      "Maximum number of incidents to return (1-1000). Default: 100. " +
+        "When more incidents match, the most severe are returned and the response includes an incidentSummary with full totals."
+    ),
+
   fields: z
     .string()
     .optional()

--- a/src/schemas/traffic/trafficSchema.ts
+++ b/src/schemas/traffic/trafficSchema.ts
@@ -40,7 +40,8 @@ export const tomtomTrafficSchema = {
     .max(1000)
     .optional()
     .describe(
-      "Maximum incidents to return (1-1000). Use 10-20 for readability in high-traffic areas."
+      "Maximum incidents to return (1-1000). Default: 100. Use 10-20 for readability in high-traffic areas. " +
+        "When more incidents match, the most severe are returned and the response includes an incidentSummary with full totals."
     ),
 
   categoryFilter: z

--- a/src/services/search/searchOrbisService.test.ts
+++ b/src/services/search/searchOrbisService.test.ts
@@ -22,6 +22,7 @@ import {
   fuzzySearch,
   reverseGeocode,
   geocodeAddress,
+  searchEVStations,
 } from "./searchOrbisService";
 import type {
   SearchResponse,
@@ -217,5 +218,26 @@ describe("Search SDK Service", () => {
 
     expect(result).toBeTruthy();
     expect(result.properties.address).toBeTruthy();
+  });
+
+  it("should keep EV result metadata consistent with features after minPowerKW filtering", async () => {
+    // Amsterdam centre is dominated by ≤11kW street chargers, so a 50kW
+    // minimum reliably filters features out client-side.
+    const result = await searchEVStations({
+      position: [4.89707, 52.377956],
+      radius: 1000,
+      minPowerKW: 50,
+      limit: 5,
+      includeAvailability: false,
+    });
+
+    expect(result).toBeDefined();
+    expect(Array.isArray(result.features)).toBe(true);
+
+    const props = result.properties as Record<string, unknown> | null | undefined;
+    if (props && props.numResults !== undefined) {
+      expect(props.numResults).toBe(result.features.length);
+      expect(props.totalResults).toBe(result.features.length);
+    }
   });
 });

--- a/src/services/search/searchOrbisService.ts
+++ b/src/services/search/searchOrbisService.ts
@@ -401,13 +401,25 @@ export async function searchEVStations(params: EVSearchParams): Promise<Places> 
   let filteredResult = searchResult;
   if (params.minPowerKW && searchResult.features?.length) {
     const minPower = params.minPowerKW;
+    const features = searchResult.features.filter((feature) => {
+      const chargingPark = (feature.properties as Record<string, unknown> | null)
+        ?.chargingPark as { connectors?: Array<{ ratedPowerKW?: number }> } | undefined;
+      if (!chargingPark?.connectors) return true;
+      return chargingPark.connectors.some((c) => (c.ratedPowerKW ?? 0) >= minPower);
+    });
+
+    // The API's numResults/totalResults describe the unfiltered response;
+    // after client-side filtering the true total is unknowable, so recompute
+    // both from the surviving features to keep metadata consistent.
     filteredResult = {
       ...searchResult,
-      features: searchResult.features.filter((feature) => {
-        const chargingPark = (feature.properties as Record<string, unknown> | null)
-          ?.chargingPark as { connectors?: Array<{ ratedPowerKW?: number }> } | undefined;
-        if (!chargingPark?.connectors) return true;
-        return chargingPark.connectors.some((c) => (c.ratedPowerKW ?? 0) >= minPower);
+      features,
+      ...(searchResult.properties && {
+        properties: {
+          ...searchResult.properties,
+          numResults: features.length,
+          totalResults: features.length,
+        },
       }),
     };
   }


### PR DESCRIPTION
## Context

Anthropic's MCP Review team reported 4 issues while evaluating this server for their directory. This PR fixes the 3 that are code bugs; the 4th (reachable-range 403) is not reproducible and is an API-key entitlement issue on the reviewer's side (see bottom).

## Fixes

### 1. `tomtom-data-viz`: `data_url` fetch failed with `Invalid IP address: undefined` (critical)

The SSRF-protection code pins DNS to a pre-validated IP via a custom `https.Agent` lookup. The callback always answered with a plain address string, but Node 20+ enables `autoSelectFamily` (Happy Eyeballs) by default, which calls lookup with `{ all: true }` and expects an **array** of `{ address, family }` entries. Node read `addresses[0].address` off the string → `undefined` → `ERR_INVALID_IP_ADDRESS` on every fetch.

The lookup now answers in the shape the options request. Security posture is unchanged: same pinned IP in both branches, hostname never re-resolved, HTTPS-only / public-unicast / no-redirect / size+timeout guards untouched.

### 2. `tomtom-traffic`: unbounded response size on large bboxes (medium)

A 0.4°×0.2° London bbox returned ~1,700–1,900 incidents (>1 MB even with compact detail). Added `capTrafficIncidents` (both backends):

- Default cap of **100** incidents; new `maxResults` (1–1000) parameter on the Orbis schema to tune it
- The **most severe** incidents survive (sorted by `magnitudeOfDelay`), so closures outrank minor jams
- An `incidentSummary` reports `totalIncidents`, `returnedIncidents`, per-category counts, and a hint to narrow the bbox / filter / raise `maxResults`
- The uncapped result is still cached for the map UI, so visualizations stay complete

Measured on the London repro: **1.15 MB / 1,740 incidents → 66 KB / 100 incidents**.

### 3. `tomtom-ev-search`: stale metadata when the power filter empties results (minor)

`minPowerKW` is filtered client-side (the API has no native support). The old code replaced `features` but spread the API's original collection properties, so `features: []` shipped with `numResults: 5 / totalResults: 100`. Both counts are now recomputed from the surviving features. (After client-side filtering the true upstream total is unknowable, so the filtered count is the only self-consistent value.)

The reviewer's "transient server isn't responding" note matches per-key QPS throttling observed during testing — not a code issue.

## How to test locally (HTTP mode)

```bash
npm ci && npm run build
node bin/tomtom-mcp-http.js        # serves MCP on http://localhost:3000/mcp
```

Then call the tools directly (no session handshake needed locally; replace `YOUR_API_KEY` with a valid TomTom API key):

**data-viz with a hosted URL (the reviewer's exact repro):**
```bash
curl -sS http://localhost:3000/mcp \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -H "tomtom-api-key: YOUR_API_KEY" \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"tomtom-data-viz","arguments":{"data_url":"https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/2.5_month.geojson","layers":[{"type":"markers"}],"title":"Earthquakes"}}}'
```
- On `main`: `{"error":"Invalid IP address: undefined"}`
- On this branch: summary with `feature_count` ≈ 1700

**traffic with the large London bbox:**
```bash
curl -sS http://localhost:3000/mcp \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -H "tomtom-api-key: YOUR_API_KEY" \
  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"tomtom-traffic","arguments":{"bbox":[-0.3,51.4,0.1,51.6]}}}'
```
- On `main`: 1,500+ incidents, ~1 MB
- On this branch: ≤100 incidents, ~66 KB, plus `incidentSummary` with full totals

**ev-search with a power filter that empties results:**
```bash
curl -sS http://localhost:3000/mcp \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -H "tomtom-api-key: YOUR_API_KEY" \
  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"tomtom-ev-search","arguments":{"position":[4.89707,52.377956],"radius":1000,"minPowerKW":50,"limit":5}}}'
```
- On `main`: `features: []` but `numResults: 5, totalResults: 100`
- On this branch: `features: []` with `numResults: 0, totalResults: 0`

To compare against the old behavior: `git checkout main && npm run build` and restart the server.

## Tests

- New unit tests: DNS-pinning lookup (both callback shapes), `capTrafficIncidents` (cap, severity ordering, summary, passthrough), EV metadata consistency
- `npx tsc --noEmit`, `npm run lint`, and the affected vitest suites all pass