### PR TITLE
Fix EV availability (LSI-578) and shrink traffic responses (LSI-579)

### DIFF
--- a/src/handlers/searchOrbisHandler.test.ts
+++ b/src/handlers/searchOrbisHandler.test.ts
@@ -82,6 +82,7 @@ const {
   createPoiSearchHandler,
   createNearbySearchHandler,
   createPOICategoriesHandler,
+  createEVSearchHandler,
 } = await import("./searchOrbisHandler");
 
 describe("createGeocodeHandler", () => {
@@ -294,5 +295,99 @@ describe("createPOICategoriesHandler", () => {
     const handler = createPOICategoriesHandler();
     const response = await handler({ filters: ["test"] });
     expect(response.isError).toBe(true);
+  });
+});
+
+describe("createEVSearchHandler", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.clearAllMocks());
+
+  // A search result enriched with the verbose SDK availability object.
+  const enrichedResult = () => ({
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [4.9, 52.37] },
+        properties: {
+          poi: { name: "Test Charger" },
+          chargingPark: {
+            connectors: [
+              {
+                connector: {
+                  type: "IEC62196Type2Outlet",
+                  ratedPowerKW: 11,
+                  currentType: "AC3",
+                  chargingSpeed: "slow",
+                },
+                count: 6,
+              },
+            ],
+            availability: {
+              id: "avail-123",
+              accessType: "Restricted",
+              openingHours: { mode: "nextSevenDays", timeRanges: [] },
+              chargingStations: [{ id: "s1", chargingPoints: [{ id: "p1", capabilities: [] }] }],
+              chargingPointAvailability: {
+                count: 6,
+                statusCounts: { Available: 2, Occupied: 3, Unknown: 1 },
+              },
+              connectorAvailabilities: [{ connector: { type: "IEC62196Type2Outlet" } }],
+            },
+          },
+        },
+      },
+    ],
+  });
+
+  it("compacts chargingPark.availability to the aggregated status summary", async () => {
+    mocks.searchService.searchEVStations.mockResolvedValue(enrichedResult());
+    const handler = createEVSearchHandler();
+    const response = await handler({ position: [4.9, 52.37], radius: 1000, show_ui: false });
+
+    const parsed = JSON.parse(response.content[0].text);
+    const availability = parsed.features[0].properties.chargingPark.availability;
+
+    // Keeps the aggregated counts the agent needs
+    expect(availability.chargingPointAvailability).toEqual({
+      count: 6,
+      statusCounts: { Available: 2, Occupied: 3, Unknown: 1 },
+    });
+    // Drops the verbose per-point detail
+    expect(availability.chargingStations).toBeUndefined();
+    expect(availability.connectorAvailabilities).toBeUndefined();
+    expect(availability.openingHours).toBeUndefined();
+    expect(availability.id).toBeUndefined();
+  });
+
+  it("returns full verbose availability when response_detail is 'full'", async () => {
+    mocks.searchService.searchEVStations.mockResolvedValue(enrichedResult());
+    const handler = createEVSearchHandler();
+    const response = await handler({
+      position: [4.9, 52.37],
+      radius: 1000,
+      show_ui: false,
+      response_detail: "full",
+    });
+
+    const parsed = JSON.parse(response.content[0].text);
+    const availability = parsed.features[0].properties.chargingPark.availability;
+    // Full mode is untrimmed — verbose detail is preserved
+    expect(availability.chargingStations).toBeDefined();
+    expect(availability.chargingPointAvailability.statusCounts.Available).toBe(2);
+  });
+
+  it("handles results without availability data", async () => {
+    const result = enrichedResult();
+    const chargingPark = result.features[0].properties.chargingPark as { availability?: unknown };
+    delete chargingPark.availability;
+    mocks.searchService.searchEVStations.mockResolvedValue(result);
+
+    const handler = createEVSearchHandler();
+    const response = await handler({ position: [4.9, 52.37], radius: 1000, show_ui: false });
+
+    const parsed = JSON.parse(response.content[0].text);
+    expect(parsed.features[0].properties.chargingPark.availability).toBeUndefined();
+    expect(response.isError).toBeUndefined();
   });
 });

--- a/src/handlers/searchOrbisHandler.ts
+++ b/src/handlers/searchOrbisHandler.ts
@@ -359,7 +359,14 @@ function trimEVSearchResponse(response: Places): Places {
 
     trimGeoJSONFeatureProperties(props);
 
-    const chargingPark = props.chargingPark as { connectors?: ConnectorInfo[] } | undefined;
+    const chargingPark = props.chargingPark as
+      | {
+          connectors?: ConnectorInfo[];
+          availability?: {
+            chargingPointAvailability?: { count?: number; statusCounts?: Record<string, number> };
+          };
+        }
+      | undefined;
     if (chargingPark?.connectors) {
       chargingPark.connectors = chargingPark.connectors.map((c: ConnectorInfo) => ({
         type: c.connector?.type,
@@ -368,6 +375,21 @@ function trimEVSearchResponse(response: Places): Places {
         chargingSpeed: c.connector?.chargingSpeed,
         count: c.count,
       })) as ConnectorInfo[];
+    }
+
+    // Real-time availability enrichment returns a verbose object (per-point
+    // detail). For the agent, keep only the aggregated counts/status summary
+    // (total + Available/Occupied/Reserved/OutOfService). Full detail remains
+    // available via response_detail:"full".
+    if (chargingPark?.availability) {
+      const cpa = chargingPark.availability.chargingPointAvailability;
+      if (cpa) {
+        chargingPark.availability = {
+          chargingPointAvailability: { count: cpa.count, statusCounts: cpa.statusCounts },
+        };
+      } else {
+        delete chargingPark.availability;
+      }
     }
   });
 

--- a/src/handlers/shared/responseTrimmer.test.ts
+++ b/src/handlers/shared/responseTrimmer.test.ts
@@ -54,10 +54,8 @@ type TrimmedSearch = {
   }>;
 };
 type TrimmedTraffic = {
-  incidents?: Array<{
-    geometry?: { type?: string; coordinates?: unknown };
-    properties?: Record<string, unknown>;
-  }>;
+  incidents?: Array<Record<string, unknown>>;
+  incidentSummary?: Record<string, unknown>;
 };
 type TrimmedReachableRange = {
   reachableRange?: { center?: { latitude: number; longitude: number }; boundary?: unknown[] };
@@ -397,7 +395,7 @@ describe("trimSearchResponse", () => {
 });
 
 describe("trimTrafficResponse", () => {
-  it("should remove coordinates from incidents", () => {
+  it("should drop the GeoJSON envelope (type/geometry/id) and flatten properties", () => {
     const response = {
       incidents: [
         {
@@ -414,48 +412,61 @@ describe("trimTrafficResponse", () => {
             id: "incident123",
             iconCategory: 6,
             magnitudeOfDelay: 2,
+            from: "Main St",
+            to: "Second Ave",
           },
         },
       ],
     };
 
-    const trimmed = trimTrafficResponse(response) as TrimmedTraffic;
+    const incident = (trimTrafficResponse(response) as TrimmedTraffic).incidents![0];
 
-    expect(trimmed.incidents![0].geometry!.type).toBe("LineString");
-    expect(trimmed.incidents![0].geometry!.coordinates).toBeUndefined();
-    expect(trimmed.incidents![0].properties!.id).toBe("incident123");
+    // Envelope and internal id are dropped; agent fields are flat on the incident
+    expect(incident.type).toBeUndefined();
+    expect(incident.geometry).toBeUndefined();
+    expect(incident.id).toBeUndefined();
+    expect(incident.properties).toBeUndefined();
+    expect(incident.iconCategory).toBe(6);
+    expect(incident.magnitudeOfDelay).toBe(2);
+    expect(incident.from).toBe("Main St");
+    expect(incident.to).toBe("Second Ave");
   });
 
-  it("should remove verbose metadata from properties", () => {
+  it("should round length, flatten events, and omit null/empty fields", () => {
     const response = {
       incidents: [
         {
           properties: {
-            id: "incident123",
-            iconCategory: 6,
-            from: "Main St",
-            to: "Second Ave",
-            tmc: { countryCode: "NL", tableNumber: "1" },
-            aci: { codes: ["abc"] },
-            numberOfReports: null,
-            lastReportTime: null,
-            probabilityOfOccurrence: "certain",
-            timeValidity: "present",
+            iconCategory: 8,
+            length: 292.308,
+            delay: null,
+            roadNumbers: [],
+            events: [
+              { code: 401, description: "Closed", iconCategory: 8 },
+              { code: 401, description: "Closed", iconCategory: 8 },
+              { code: 705, description: "Roadworks", iconCategory: 8 },
+            ],
           },
         },
       ],
     };
 
-    const trimmed = trimTrafficResponse(response) as TrimmedTraffic;
+    const incident = (trimTrafficResponse(response) as TrimmedTraffic).incidents![0];
 
-    expect(trimmed.incidents![0].properties!.id).toBe("incident123");
-    expect(trimmed.incidents![0].properties!.from).toBe("Main St");
-    expect(trimmed.incidents![0].properties!.tmc).toBeUndefined();
-    expect(trimmed.incidents![0].properties!.aci).toBeUndefined();
-    expect(trimmed.incidents![0].properties!.numberOfReports).toBeUndefined();
-    expect(trimmed.incidents![0].properties!.lastReportTime).toBeUndefined();
-    expect(trimmed.incidents![0].properties!.probabilityOfOccurrence).toBeUndefined();
-    expect(trimmed.incidents![0].properties!.timeValidity).toBeUndefined();
+    expect(incident.length).toBe(292); // rounded
+    expect(incident.delay).toBeUndefined(); // null omitted
+    expect(incident.roadNumbers).toBeUndefined(); // empty omitted
+    expect(incident.events).toEqual(["Closed", "Roadworks"]); // deduped descriptions
+  });
+
+  it("should preserve a sibling incidentSummary added by the cap", () => {
+    const response = {
+      incidents: [{ properties: { iconCategory: 1 } }],
+      incidentSummary: { totalIncidents: 500, truncated: true },
+    };
+
+    const trimmed = trimTrafficResponse(response) as TrimmedTraffic;
+    expect(trimmed.incidentSummary).toEqual({ totalIncidents: 500, truncated: true });
   });
 
   it("should return original response if no incidents", () => {
@@ -466,7 +477,10 @@ describe("trimTrafficResponse", () => {
 });
 
 describe("capTrafficIncidents", () => {
-  type CappedTraffic = TrimmedTraffic & {
+  // capTrafficIncidents runs on the raw response (before trimming), so incidents
+  // still carry their nested `properties`.
+  type CappedTraffic = {
+    incidents?: Array<{ properties?: Record<string, unknown> }>;
     incidentSummary?: {
       totalIncidents: number;
       returnedIncidents: number;

--- a/src/handlers/shared/responseTrimmer.ts
+++ b/src/handlers/shared/responseTrimmer.ts
@@ -441,28 +441,43 @@ export function trimSearchResponse(response: unknown, backend?: Backend): unknow
  */
 export function trimTrafficResponse(response: unknown, _backend?: Backend): unknown {
   const resp = response as TrafficResponse;
-  if (!resp) return response;
+  if (!resp?.incidents) return response;
 
-  const trimmed = deepClone(resp);
+  // Rebuild each incident keeping only agent-relevant fields. Dropping the
+  // GeoJSON envelope (type/geometry — coordinates are visualization-only and
+  // already useless without them), the long internal `id`, and null/empty
+  // fields cuts the agent payload ~4x on dense bboxes. The full untrimmed
+  // result is still cached for the map UI, so nothing visual is lost.
+  const incidents = resp.incidents.map((incident) => {
+    const p = (incident.properties ?? {}) as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
 
-  trimmed.incidents?.forEach((incident) => {
-    // COMMON: Remove large coordinate arrays (used for map visualization only)
-    if (incident.geometry) {
-      delete incident.geometry.coordinates;
+    if (p.iconCategory !== undefined) out.iconCategory = p.iconCategory;
+    if (p.magnitudeOfDelay !== undefined) out.magnitudeOfDelay = p.magnitudeOfDelay;
+    if (p.from) out.from = p.from;
+    if (p.to) out.to = p.to;
+    if (typeof p.length === "number") out.length = Math.round(p.length);
+    if (p.delay != null) out.delay = p.delay;
+    if (Array.isArray(p.roadNumbers) && p.roadNumbers.length) out.roadNumbers = p.roadNumbers;
+    if (p.startTime) out.startTime = p.startTime;
+    if (p.endTime) out.endTime = p.endTime;
+
+    // Flatten events ({code, description, iconCategory}) to unique descriptions —
+    // code/iconCategory duplicate fields already on the incident.
+    if (Array.isArray(p.events) && p.events.length) {
+      const descriptions = [
+        ...new Set(
+          (p.events as Array<{ description?: string }>).map((e) => e?.description).filter(Boolean)
+        ),
+      ];
+      if (descriptions.length) out.events = descriptions;
     }
 
-    // COMMON: Remove verbose metadata
-    if (incident.properties) {
-      delete incident.properties.tmc;
-      delete incident.properties.aci;
-      delete incident.properties.numberOfReports;
-      delete incident.properties.lastReportTime;
-      delete incident.properties.probabilityOfOccurrence;
-      delete incident.properties.timeValidity;
-    }
+    return out;
   });
 
-  return trimmed;
+  // Preserve sibling top-level fields (e.g. incidentSummary added by the cap).
+  return { ...resp, incidents };
 }
 
 /** Default maximum incidents returned to the agent (large bboxes can return thousands). */
@@ -577,22 +592,21 @@ export function trimReachableRangeResponse(response: unknown, _backend?: Backend
 export async function buildCompressedResponse<T>(
   trimmedData: T,
   fullData: T,
-  showUI: boolean = true
+  showUI: boolean = true,
+  pretty: boolean = true
 ): Promise<MCPResponse> {
+  // Compact serialization (no indentation) roughly halves whitespace overhead;
+  // used for high-cardinality responses like traffic. Defaults to pretty so
+  // other tools' output is unchanged.
+  const indent = pretty ? 2 : undefined;
+
   // If UI is disabled, don't cache the full data
   if (!showUI) {
     return {
       content: [
         {
           type: "text" as const,
-          text: JSON.stringify(
-            {
-              ...trimmedData,
-              _meta: { show_ui: false },
-            },
-            null,
-            2
-          ),
+          text: JSON.stringify({ ...trimmedData, _meta: { show_ui: false } }, null, indent),
         },
       ],
     };
@@ -606,12 +620,9 @@ export async function buildCompressedResponse<T>(
       {
         type: "text" as const,
         text: JSON.stringify(
-          {
-            ...trimmedData,
-            _meta: { show_ui: true, viz_id: vizId },
-          },
+          { ...trimmedData, _meta: { show_ui: true, viz_id: vizId } },
           null,
-          2
+          indent
         ),
       },
     ],

--- a/src/handlers/trafficHandler.ts
+++ b/src/handlers/trafficHandler.ts
@@ -67,8 +67,9 @@ export function createTrafficHandler() {
         return { content: [{ type: "text" as const, text: JSON.stringify(capped, null, 2) }] };
       }
 
+      // Compact JSON (no indentation) to minimise tokens on dense bboxes.
       const trimmed = trimTrafficResponse(capped, BACKEND);
-      return { content: [{ type: "text" as const, text: JSON.stringify(trimmed, null, 2) }] };
+      return { content: [{ type: "text" as const, text: JSON.stringify(trimmed) }] };
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       logger.error({ error: message }, "Traffic lookup failed");

--- a/src/handlers/trafficOrbisHandler.ts
+++ b/src/handlers/trafficOrbisHandler.ts
@@ -70,9 +70,10 @@ export function createTrafficHandler() {
         return { content: [{ type: "text" as const, text: JSON.stringify(response, null, 2) }] };
       }
 
-      // Trimmed for agent, full data cached for Apps
+      // Trimmed for agent, full data cached for Apps.
+      // pretty=false: compact JSON to minimise tokens on dense bboxes.
       const trimmed = trimTrafficResponse(capped, BACKEND);
-      return await buildCompressedResponse(trimmed, result, show_ui);
+      return await buildCompressedResponse(trimmed, result, show_ui, false);
     } catch (error: unknown) {
       const formattedError = handleApiError(error, "Traffic lookup (Orbis)");
       logger.error({ error: formattedError.message }, "❌ Traffic lookup failed");

--- a/src/services/search/searchOrbisService.ts
+++ b/src/services/search/searchOrbisService.ts
@@ -37,6 +37,7 @@ import { getEffectiveApiKey } from "../base/tomtomClient";
 import { logger } from "../../utils/logger";
 import buffer from "@turf/buffer";
 import type { Polygon, Position } from "geojson";
+import { TomTomConfig } from "@tomtom-org/maps-sdk/core";
 import type { BBox, Language, Places, POICategory, Routes } from "@tomtom-org/maps-sdk/core";
 
 // Options shared by multiple search functions
@@ -427,6 +428,10 @@ export async function searchEVStations(params: EVSearchParams): Promise<Places> 
   // Enrich with real-time availability if requested
   if (params.includeAvailability !== false && filteredResult.features?.length > 0) {
     try {
+      // getPlacesWithEVAvailability takes no key argument — it reads the API key
+      // from the SDK global config, which the per-call search() path never set,
+      // so the availability requests went out unauthenticated and were dropped.
+      TomTomConfig.instance.put({ apiKey });
       const enriched = await getPlacesWithEVAvailability(filteredResult);
       logger.debug(
         { stationCount: enriched.features?.length },

--- a/tests/test-http-tools.js
+++ b/tests/test-http-tools.js
@@ -234,6 +234,11 @@ function validateGeoJSONReachableRangeResponse(data, mode) {
 /**
  * Validate traffic response.
  * Expected: { incidents: [...] }
+ *
+ * Shape differs by response_detail (LSI-579):
+ *   - "full": untrimmed GeoJSON Features (incident has type/geometry/properties)
+ *   - "compact" (default): flat incidents — agent-relevant fields hoisted to the
+ *     top level, GeoJSON envelope (type/geometry) and the long internal id dropped.
  */
 function validateTrafficResponse(data, mode) {
   if (!data.hasOwnProperty("incidents")) return "missing incidents key";
@@ -241,7 +246,18 @@ function validateTrafficResponse(data, mode) {
   // incidents can be empty (no traffic issues), that's fine
   if (data.incidents.length > 0) {
     const inc = data.incidents[0];
-    if (!inc.properties && !inc.type) return "incident[0] missing properties/type";
+    if (mode === "full") {
+      if (!inc.properties && !inc.type) return "incident[0] missing properties/type";
+    } else {
+      // Compact incidents are flat — must NOT carry the GeoJSON envelope...
+      if (inc.type || inc.geometry || inc.properties) {
+        return "compact incident[0] should be flat (no type/geometry/properties)";
+      }
+      // ...and should expose the hoisted fields.
+      if (inc.iconCategory === undefined && !inc.from && !inc.to && !inc.events) {
+        return "compact incident[0] missing expected fields (iconCategory/from/to/events)";
+      }
+    }
   }
   return null;
 }


### PR DESCRIPTION
Fixes two Anthropic review findings: **LSI-578** (EV availability) and **LSI-579** (traffic response size).

**Jira:** [LSI-578](https://tomtom.atlassian.net/browse/LSI-578) · [LSI-579](https://tomtom.atlassian.net/browse/LSI-579)

---

## 🔌 tomtom-ev-search — real-time availability now works (LSI-578)

**Problem:** `includeAvailability: true` did nothing — every station came back with only `connectors`, no live status.
**Cause:** the availability lookup reads the API key from the SDK's global config, which our per-call search path never set, so the request went out unauthenticated and was silently dropped.
**Fix:** set the key before the availability lookup, and surface a compact `availability` summary on each station.

**What changed in the response** (everything else is identical):

| Field | Before | After |
|---|---|---|
| `chargingPark.connectors` | ✅ present | ✅ present (unchanged) |
| `chargingPark.availability` | ❌ missing | ✅ **added** — live status |

The new `availability` block:
```json
"availability": {
  "chargingPointAvailability": {
    "count": 6,
    "statusCounts": { "Available": 3, "Occupied": 3 }
  }
}
```

---

## 🚦 tomtom-traffic — responses ~4× smaller (LSI-579)

**Problem:** a busy area (e.g. London) returned ~66 KB even after the earlier cap — too big for an agent's context.
**Cause:** each incident shipped the full GeoJSON envelope, a long internal id, null/empty fields, verbose event objects, and pretty-print whitespace.
**Fix:** return one flat record per incident with only the useful fields, in compact JSON (the map UI still gets the full data).

**What changed per incident** (same 100 incidents, ~66 KB → ~18 KB):

| Field | Before | After |
|---|---|---|
| `iconCategory`, `magnitudeOfDelay`, `from`, `to`, `startTime` | ✅ | ✅ kept |
| `length` | `299.6188593002` | `300` (rounded) |
| `events` | `[{code, description, iconCategory}]` | `["Closed", "Roadworks"]` (descriptions only) |
| `delay`, `endTime`, `roadNumbers` | always present (often `null`/`[]`) | only when they have a value |
| `id` (internal `TTI-…`) | ✅ present | ❌ removed |
| `type: "Feature"` | ✅ present | ❌ removed |
| `geometry` | ✅ present (no coordinates) | ❌ removed |

Before:
```json
{ "type": "Feature", "properties": { "id": "TTI-b2fe…", "iconCategory": 8, "magnitudeOfDelay": 4, "from": "Queen Elizabeth Road (A307)", "to": "A2043", "length": 299.6188593002, "delay": null, "roadNumbers": ["A308"], "endTime": null, "events": [{ "code": 401, "description": "Closed", "iconCategory": 8 }] }, "geometry": { "type": "LineString" } }
```
After:
```json
{ "iconCategory": 8, "magnitudeOfDelay": 4, "from": "Queen Elizabeth Road (A307)", "to": "A2043", "length": 300, "roadNumbers": ["A308"], "startTime": "2026-06-22T03:13:00Z", "events": ["Closed", "Roadworks"] }
```

---

## ✅ How to test

Run against **local** (this branch) and **remote** (current prod) and compare. The pipe parses the SSE response and pretty-prints the tool's JSON so you can diff it easily (instead of reading escaped text).

**EV search**
```bash
# LOCAL (fixed)
curl -s 'http://localhost:3000/mcp' \
  -H 'Accept: application/json,text/event-stream' \
  -H 'Content-Type: application/json' \
  -H 'tomtom-api-key: YOUR_API_KEY' \
  -H 'tomtom-maps-backend: tomtom-orbis-maps' \
  --data '{"method":"tools/call","params":{"name":"tomtom-ev-search","arguments":{"position":[4.89707,52.377956],"radius":3000,"limit":3,"includeAvailability":true}},"jsonrpc":"2.0","id":25}' \
  | grep '^data:' | sed 's/^data: //' | jq -r '.result.content[0].text' | jq .

# REMOTE (current prod) — same call, swap the URL + key
curl -s 'https://mcp.tomtom.com/maps' \
  -H 'Accept: application/json,text/event-stream' \
  -H 'Content-Type: application/json' \
  -H 'tomtom-api-key: YOUR_API_KEY' \
  --data '{"method":"tools/call","params":{"name":"tomtom-ev-search","arguments":{"position":[4.89707,52.377956],"radius":3000,"limit":3,"includeAvailability":true}},"jsonrpc":"2.0","id":25}' \
  | grep '^data:' | sed 's/^data: //' | jq -r '.result.content[0].text' | jq .
```
→ Local shows `chargingPark.availability`; remote does not.

**Traffic**
```bash
# LOCAL (fixed)
curl -s 'http://localhost:3000/mcp' \
  -H 'Accept: application/json,text/event-stream' \
  -H 'Content-Type: application/json' \
  -H 'tomtom-api-key: YOUR_API_KEY' \
  -H 'tomtom-maps-backend: tomtom-orbis-maps' \
  --data '{"method":"tools/call","params":{"name":"tomtom-traffic","arguments":{"bbox":[-0.3,51.4,0.1,51.6]}},"jsonrpc":"2.0","id":26}' \
  | grep '^data:' | sed 's/^data: //' | jq -r '.result.content[0].text' | jq .

# REMOTE (current prod) — same call, swap the URL + key
curl -s 'https://mcp.tomtom.com/maps' \
  -H 'Accept: application/json,text/event-stream' \
  -H 'Content-Type: application/json' \
  -H 'tomtom-api-key: YOUR_API_KEY' \
  --data '{"method":"tools/call","params":{"name":"tomtom-traffic","arguments":{"bbox":[-0.3,51.4,0.1,51.6]}},"jsonrpc":"2.0","id":26}' \
  | grep '^data:' | sed 's/^data: //' | jq -r '.result.content[0].text' | jq .
```
→ Local is compact flat incidents; remote is the larger pretty-printed format.

_Start the local server with `npm run build && node bin/tomtom-mcp-http.js` (listens on `http://localhost:3000/mcp`)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
