### PR TITLE
Bump maps-sdk to 0.49.0; pass apiKey directly to EV availability (maps-sdk-js#1888)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@rollup/plugin-typescript": "^12.3.0",
-        "@tomtom-org/maps-sdk": "^0.48.3",
+        "@tomtom-org/maps-sdk": "^0.49.0",
         "@turf/buffer": "^7.3.4",
         "@types/pako": "^2.0.4",
         "axios": "^1.13.6",
@@ -3239,9 +3239,9 @@
       "license": "MIT"
     },
     "node_modules/@tomtom-org/maps-sdk": {
-      "version": "0.48.3",
-      "resolved": "https://registry.npmjs.org/@tomtom-org/maps-sdk/-/maps-sdk-0.48.3.tgz",
-      "integrity": "sha512-9rmR5xihcWr5UZgzkRQdTLz6QqpUWg1LZ5qMt9cxcGlYadd5o06wMw4r/ndFoTuGatCDr5ujHNtAlQ2M/+plug==",
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@tomtom-org/maps-sdk/-/maps-sdk-0.49.0.tgz",
+      "integrity": "sha512-id8i6jJvxtQU84gBw8867CiA4L5l5uPO75fMPew7+i3dPyzLQQve4KsWsP7alwVnlpwM9WxDWbEUEULj62bXNA==",
       "hasInstallScript": true,
       "license": "See in LICENSE.txt",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-typescript": "^12.3.0",
-    "@tomtom-org/maps-sdk": "^0.48.3",
+    "@tomtom-org/maps-sdk": "^0.49.0",
     "@turf/buffer": "^7.3.4",
     "@types/pako": "^2.0.4",
     "axios": "^1.13.6",

--- a/src/services/search/searchOrbisService.ts
+++ b/src/services/search/searchOrbisService.ts
@@ -428,9 +428,16 @@ export async function searchEVStations(params: EVSearchParams): Promise<Places> 
   // Enrich with real-time availability if requested
   if (params.includeAvailability !== false && filteredResult.features?.length > 0) {
     try {
-      // getPlacesWithEVAvailability takes no key argument — it reads the API key
-      // from the SDK global config, which the per-call search() path never set,
-      // so the availability requests went out unauthenticated and were dropped.
+      // On the current SDK (0.48.3) getPlacesWithEVAvailability takes no key
+      // argument — it reads the API key from the SDK global config. The per-call
+      // search() path never sets that, so the per-station availability requests
+      // went out unauthenticated (401) and were silently dropped. Set the key on
+      // the global config right before the call so those requests authenticate.
+      //
+      // TODO(maps-sdk-js#1888): once the SDK release forwards common service
+      // params to this helper, pass the key directly and delete both this line
+      // and the TomTomConfig import:
+      //   const enriched = await getPlacesWithEVAvailability(filteredResult, { apiKey });
       TomTomConfig.instance.put({ apiKey });
       const enriched = await getPlacesWithEVAvailability(filteredResult);
       logger.debug(

--- a/src/services/search/searchOrbisService.ts
+++ b/src/services/search/searchOrbisService.ts
@@ -37,7 +37,6 @@ import { getEffectiveApiKey } from "../base/tomtomClient";
 import { logger } from "../../utils/logger";
 import buffer from "@turf/buffer";
 import type { Polygon, Position } from "geojson";
-import { TomTomConfig } from "@tomtom-org/maps-sdk/core";
 import type { BBox, Language, Places, POICategory, Routes } from "@tomtom-org/maps-sdk/core";
 
 // Options shared by multiple search functions
@@ -428,18 +427,10 @@ export async function searchEVStations(params: EVSearchParams): Promise<Places> 
   // Enrich with real-time availability if requested
   if (params.includeAvailability !== false && filteredResult.features?.length > 0) {
     try {
-      // On the current SDK (0.48.3) getPlacesWithEVAvailability takes no key
-      // argument — it reads the API key from the SDK global config. The per-call
-      // search() path never sets that, so the per-station availability requests
-      // went out unauthenticated (401) and were silently dropped. Set the key on
-      // the global config right before the call so those requests authenticate.
-      //
-      // TODO(maps-sdk-js#1888): once the SDK release forwards common service
-      // params to this helper, pass the key directly and delete both this line
-      // and the TomTomConfig import:
-      //   const enriched = await getPlacesWithEVAvailability(filteredResult, { apiKey });
-      TomTomConfig.instance.put({ apiKey });
-      const enriched = await getPlacesWithEVAvailability(filteredResult);
+      // Forward the API key to the per-station availability requests. Since SDK
+      // 0.49.0 (maps-sdk-js#1888) this helper accepts common service params;
+      // otherwise it reads the key from global config, which we never set.
+      const enriched = await getPlacesWithEVAvailability(filteredResult, { apiKey });
       logger.debug(
         { stationCount: enriched.features?.length },
         "EV availability enrichment successful"


### PR DESCRIPTION
## What
- Bump `@tomtom-org/maps-sdk` `0.48.3 → 0.49.0`.
- Pass the API key **directly** to EV availability enrichment:
  ```ts
  const enriched = await getPlacesWithEVAvailability(filteredResult, { apiKey });
  ```
- Remove the previous global-config workaround (`TomTomConfig.instance.put({ apiKey })`) and its `TomTomConfig` import from `searchOrbisService`.

## Why
On `0.48.3`, `getPlacesWithEVAvailability` took no key argument — it read the key from the SDK global config, which our per-call `search()` path never set, so per-station availability requests went out unauthenticated (401) and were silently dropped. We worked around it by setting the global config before the call.

[maps-sdk-js#1888](https://github.com/tomtom-internal/maps-sdk-js/pull/1888), shipped in **`0.49.0`**, makes this helper accept + forward common service params, so the key can be passed directly — cleaner, and no global mutable state (better for the multi-tenant HTTP server where each request carries its own key).

## Verification
- `tsc` clean
- Full test suite **471/471** green on `0.49.0` (no regressions from the minor bump)
- `npm run build` OK
- **Live**: ran the built server and confirmed EV availability still populates — `chargingPark.availability.chargingPointAvailability` with `count` + `Available/Occupied` status counts.

## Notes
- The MCP App widgets (`src/apps/.../sdk-config.ts`) still use `TomTomConfig` for their own SDK setup — intentionally untouched; this change is scoped to `searchEVStations`.
- Net diff vs `main`: SDK bump + the direct-key swap (an interim commit added a TODO, which this PR's swap commit then removes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)