### PR TITLE
fix: restore maps-sdk global user-agent for Orbis SDK calls

### DIFF
--- a/src/services/base/tomtomClient.ts
+++ b/src/services/base/tomtomClient.ts
@@ -17,6 +17,7 @@
 import axios, { AxiosInstance } from "axios";
 import dotenv from "dotenv";
 import { AsyncLocalStorage } from "async_hooks";
+import { TomTomConfig } from "@tomtom-org/maps-sdk/core";
 import { getAppConfig } from "../../appConfig";
 import { logger } from "../../utils/logger";
 import { VERSION } from "../../version";
@@ -48,6 +49,15 @@ export const tomtomClient: AxiosInstance = axios.create({
     "TomTom-User-Agent": `TomTomMCPSDK/${VERSION}`,
   },
 });
+
+// Tag the maps-sdk global config with the same default user-agent so Orbis SDK
+// service calls (search/geocode/calculateRoute) are attributed to the MCP and
+// not the SDK's default "MapsSDKJS/<ver>". The SDK reads `tomtom-user-agent`
+// from its global config at runtime, though the key is absent from the public
+// GlobalConfig type — hence the cast. setHttpMode() overrides this in HTTP mode.
+TomTomConfig.instance.put({ "tomtom-user-agent": `TomTomMCPSDK/${VERSION}` } as unknown as Parameters<
+  typeof TomTomConfig.instance.put
+>[0]);
 
 // Request interceptor to add API key dynamically
 tomtomClient.interceptors.request.use(
@@ -197,15 +207,20 @@ export function setHttpMode(): void {
       ? process.env.MCP_TRANSPORT_MODE.trim()
       : "TomTomMCPSDKHttp";
 
+  const userAgent = `${mcpTransportModeType}/${VERSION}`;
+
   // Update the user-agent header to reflect HTTP mode
   if (tomtomClient.defaults.headers) {
-    tomtomClient.defaults.headers["TomTom-User-Agent"] = `${mcpTransportModeType}/${VERSION}`;
+    tomtomClient.defaults.headers["TomTom-User-Agent"] = userAgent;
   }
 
-  logger.debug(
-    { user_agent: `${mcpTransportModeType}/${VERSION}` },
-    "TomTom MCP client set to HTTP mode"
-  );
+  // Keep the maps-sdk global config in sync so Orbis SDK calls carry the same
+  // HTTP-mode identifier (see module-level put above for details).
+  TomTomConfig.instance.put({ "tomtom-user-agent": userAgent } as unknown as Parameters<
+    typeof TomTomConfig.instance.put
+  >[0]);
+
+  logger.debug({ user_agent: userAgent }, "TomTom MCP client set to HTTP mode");
 }
 
 /**


### PR DESCRIPTION
## Problem

Orbis tools route their outbound TomTom API calls through the **maps-sdk** (`search()` / `geocode()` / `calculateRoute()` in `searchOrbisService` / `routingOrbisService`), which bypasses the axios `tomtomClient`. The MCP user-agent (`TomTom-User-Agent: TomTomMCPSDKHttp/<ver>`) is only set on the axios client, so **Orbis calls never carried it** — they went out as the SDK default `MapsSDKJS/<ver>`.

Impact: in API analytics, Orbis traffic is attributed to the generic SDK `sdk_name`, not `TomTomMCPSDKHttp`, so **MCP usage has been badly undercounted** (the `TomTomMCPSDKHttp` series captures only the remaining axios-path calls).

## Root cause / history

This was originally fixed in **`f1ad0b2`** ("added headers to current codebase", 2026-03-16) — but that branch was **never merged**. The Orbis→SDK migration that actually landed, **`d95710d`** ("feat!: reuse SDK in all MCP Orbis tools", 2026-03-20), came from a separate branch that didn't include the fix. So the SDK user-agent setup was silently dropped.

## Fix

The maps-sdk reads a `tomtom-user-agent` key off its global config at runtime (confirmed in `@tomtom-org/maps-sdk/core` 0.49.0: `"tomtom-user-agent": A["tomtom-user-agent"] ?? "MapsSDKJS/0.49.0"`). So set it via `TomTomConfig.instance.put(...)`:

- at module load → stdio default (`TomTomMCPSDK/<ver>`)
- in `setHttpMode()` → HTTP-mode identifier, kept in sync with the axios header

The key isn't in the public `GlobalConfig` type, so it's set via a cast (as in the original `f1ad0b2`).

## Verification

Verified locally against a running HTTP server: an Orbis `tomtom-ev-search` call now emits `tomtom-user-agent: TomTomMCPSDKHttp/<ver>` on the outbound SDK request instead of `MapsSDKJS/<ver>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)