### PR TITLE
LSI-31 Build release image from bumped commit instead of retagging main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - main
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 permissions:
   contents: write
   packages: write
@@ -52,68 +48,32 @@ jobs:
           version=$(yq -r '.version' package.json)
           echo "version=$version" >> $GITHUB_OUTPUT
 
+  # Build the release image directly from the version-bump commit that triggered
+  # this workflow, so the version baked into the image (src/version.ts, generated
+  # from package.json at build time) matches the release tag. Previously this job
+  # retagged the pre-bump `main` image, which left the image reporting the prior
+  # version. Mirrors the build.yml invocation, adding the versioned + latest tags.
   tag-release-image:
-    runs-on: ubuntu-22.04
     needs: [get-version]
-    steps:
-      - name: Log in to Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
+    permissions:
+      contents: read
+      packages: write
+    uses: docker/github-builder/.github/workflows/build.yml@v1
+    with:
+      output: image
+      push: true
+      platforms: linux/amd64,linux/arm64
+      meta-images: ghcr.io/${{ github.repository }}
+      meta-tags: |
+        type=raw,value=v${{ needs.get-version.outputs.version }}
+        type=raw,value=latest
+      sign: false
+      cache: true
+    secrets:
+      registry-auths: |
+        - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get latest main SHA tag from package repository
-        id: get-sha
-        run: |
-          REPO_OWNER="${{ github.repository_owner }}"
-          REPO_NAME="$(basename ${{ github.repository }})"
-
-          # Check if the repo belongs to an org or user
-          TYPE_CHECK=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/users/${REPO_OWNER}" | \
-            jq -r '.type')
-
-          if [[ "$TYPE_CHECK" == "Organization" ]]; then
-            OWNER_TYPE="orgs"
-          else
-            OWNER_TYPE="users"
-          fi
-
-          MAIN_SHA=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/${OWNER_TYPE}/${REPO_OWNER}/packages/container/${REPO_NAME}/versions" | \
-            jq -r '.[] | select(.metadata.container.tags | index("main")) | .metadata.container.tags[]' | grep '^sha-')
-          echo "main_sha=$MAIN_SHA" >> $GITHUB_OUTPUT
-          echo "Main SHA: $MAIN_SHA"
-
-      - name: Pull, retag and push release image
-        run: |
-          # Ensure image names are all lowercase
-          REPO_NAME_LOWER=$(echo "${{ env.IMAGE_NAME }}" | tr '[:upper:]' '[:lower:]')
-
-          # Source image with SHA tag
-          SOURCE_IMAGE="${{ env.REGISTRY }}/${REPO_NAME_LOWER}:${{ steps.get-sha.outputs.main_sha }}"
-          # Target image with release tag
-          TARGET_IMAGE="${{ env.REGISTRY }}/${REPO_NAME_LOWER}:v${{ needs.get-version.outputs.version }}"
-          # Latest tag
-          LATEST_IMAGE="${{ env.REGISTRY }}/${REPO_NAME_LOWER}:latest"
-
-          echo "Pulling source image: $SOURCE_IMAGE"
-          docker pull $SOURCE_IMAGE
-
-          echo "Tagging as: $TARGET_IMAGE"
-          docker tag $SOURCE_IMAGE $TARGET_IMAGE
-
-          echo "Tagging as: $LATEST_IMAGE"
-          docker tag $SOURCE_IMAGE $LATEST_IMAGE
-
-          echo "Pushing release image: $TARGET_IMAGE"
-          docker push $TARGET_IMAGE
-
-          echo "Pushing latest image: $LATEST_IMAGE"
-          docker push $LATEST_IMAGE
 
   add-release-artifacts:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Description

The hosted MCP endpoint reports a version one release behind (e.g. `serverInfo.version = 1.6.5` after the 1.6.6 release), even though npm `@tomtom-org/tomtom-mcp@1.6.6` is correct.

**Root cause:** `serverInfo.version` is baked from `package.json.version` → `src/version.ts` by `scripts/generate-version.cjs`, which runs during `npm run build` inside the Docker image build. The release flow publishes a GitHub Release on the current `main` HEAD; `prepare-release.yml` then bumps the version and commits `Release version 'vX'` (author `github-actions[bot]`). That bump commit is **skipped** by `build.yml`, so no image is ever built from it. `release.yml`'s `tag-release-image` merely **retagged the pre-bump `main` image** as `v<version>`, so the released image's baked-in version lagged the tag by one release. (Verified: `v1.6.6` was `sha-2e8c260` retagged, whose `package.json` was `1.6.5`.)

Note: only the **version string** lagged — the deployed code was functionally correct (the bump commit changes only three version strings).

**Fix:** `tag-release-image` now builds the versioned image directly from the bump commit (the triggering commit) via the same `docker/github-builder` reusable workflow that `build.yml` uses, tagging it `v<version>` + `latest`. Since the Dockerfile runs `npm run build` → `generate-version.cjs` regenerates `src/version.ts` from the bumped `package.json`, the image contents and tag now agree. This mirrors how the `publish-npm` job already builds npm fresh. Also removes the now-unused `REGISTRY`/`IMAGE_NAME` env and the GHCR `sha`-lookup/retag steps.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Validated `release.yml` YAML parses and job graph is intact (`pre-check → get-version → tag-release-image → add-release-artifacts / publish-npm`).
- [x] Confirmed on the bumped commit that `generate-version.cjs` produces `VERSION = "1.6.6"` matching `package.json`, proving a build from the bump commit bakes the correct version.
- [ ] End-to-end (post-merge): cut `v1.6.7`, confirm `tag-release-image` **builds** (not retags) and pushes `ghcr.io/tomtom-international/tomtom-maps-mcp:v1.6.7`, then after the infra tag bump verify `initialize` on `https://mcp.tomtom.com/maps` reports `1.6.7`.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)