### PR TITLE
chore(): remove unnecessary sleep LSI-52

### DIFF
--- a/src/services/search/searchOrbisService.test.ts
+++ b/src/services/search/searchOrbisService.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   searchPlaces,
   poiSearch,
@@ -29,11 +29,6 @@ import type {
   GeocodingResponse,
   ReverseGeocodingResponse,
 } from "@tomtom-org/maps-sdk/services";
-
-beforeEach(async () => {
-  // TODO(LSI-52) Implement robust way of awaiting loading of dependencies.
-  await new Promise((resolve) => setTimeout(resolve, 500));
-});
 
 // Real tests using SDK — responses are GeoJSON FeatureCollections
 describe("Search SDK Service", () => {

--- a/src/services/search/searchService.test.ts
+++ b/src/services/search/searchService.test.ts
@@ -28,7 +28,9 @@ import type { POIResult, ReverseGeocodingResult } from "./types";
 import { beforeEach } from "vitest";
 
 beforeEach(async () => {
-  // TODO(LSI-52) Implement robust way of awaiting loading of dependencies.
+  // These tests hit the live TomTom API through the legacy axios client, which
+  // (unlike the maps-sdk) does not retry on 429. Space out requests to stay
+  // under the rate limit.
   await new Promise((resolve) => setTimeout(resolve, 500));
 });
 


### PR DESCRIPTION
Now that we don't have slow-loading native dependencies anymore, these sleeps are not necessary.