### PR TITLE
feat: project selection for workforce tenant users

### DIFF
--- a/.github/workflows/veracode.yml
+++ b/.github/workflows/veracode.yml
@@ -43,14 +43,18 @@ jobs:
         # The scan action exits 0 even when scan creation fails (e.g. HTTP 401
         # on invalid credentials), which produced green checks with no scan.
         # A completed scan always writes results.json.
-        if: ${{ github.event_name == 'pull_request' }}
+        # !cancelled(): also run when the scan step failed the job on new
+        # findings, so the full-results upload below still happens.
+        if: ${{ github.event_name == 'pull_request' && !cancelled() }}
         run: test -s results.json || { echo "::error::Veracode pipeline scan produced no results (credential or upload failure) — check the scan step log"; exit 1; }
 
       - name: Upload full scan results
         # The scan action only uploads filtered_results.json; the full
         # results.json is needed to inspect findings and to (re)generate the
         # baseline file (see docs/veracode-findings-triage.md).
-        if: ${{ github.event_name == 'pull_request' }}
+        # !cancelled(): a scan that fails the build on new findings is exactly
+        # when the full results are needed to refresh the baseline.
+        if: ${{ github.event_name == 'pull_request' && !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: veracode-full-results

--- a/src/appConfig.ts
+++ b/src/appConfig.ts
@@ -27,6 +27,9 @@ export interface AppConfig {
   ulsTokenEndpoint: string;
   ulsClientId: string;
   ulsResource: string;
+  accountApiBaseUrl: string;
+  accountApiAudience: string;
+  accountApiScope: string;
   tomtomApiBaseUrl: string;
   tomtomApiKey: string | undefined;
   mcpTransportMode: string | undefined;
@@ -40,7 +43,7 @@ export function getAppConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
     /** Base URL for the MCP API */
     baseUrl: env.MCP_BASE_URL || `http://localhost:${env.PORT || 3000}`,
 
-    baseUrlPath: (env.MCP_BASE_URL_PATH || '').replace(/\/$/, ''),
+    baseUrlPath: (env.MCP_BASE_URL_PATH || "").replace(/\/$/, ""),
 
     /** Comma-separated list of allowed CORS origins */
     allowedOrigins: env.ALLOWED_ORIGINS,
@@ -72,6 +75,15 @@ export function getAppConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
 
     /** ULS token exchange resource — the API the resolved key is for */
     ulsResource: env.ULS_RESOURCE || "https://api.tomtom.com",
+
+    /** Base URL for account/contract API calls */
+    accountApiBaseUrl: env.ACCOUNT_API_BASE_URL || "https://account.cx.tomtom.com",
+
+    /** Audience of the token exchanged for account management API calls */
+    accountApiAudience: env.ACCOUNT_API_AUDIENCE || "https://account.cx.tomtom.com",
+
+    /** Scope requested for the account management API token */
+    accountApiScope: env.ACCOUNT_API_SCOPE || "authorize",
 
     /** TomTom API base URL */
     tomtomApiBaseUrl: env.TOMTOM_API_BASE_URL || "https://api.tomtom.com",

--- a/src/auth/jwtVerifier.ts
+++ b/src/auth/jwtVerifier.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { createRemoteJWKSet, decodeJwt, jwtVerify, type JWTVerifyGetKey } from "jose";
+import {
+  createRemoteJWKSet,
+  decodeJwt,
+  jwtVerify,
+  type JWTPayload,
+  type JWTVerifyGetKey,
+} from "jose";
 import { logger } from "../utils/logger";
 
 const ALLOWED_ALGORITHMS = ["ES256", "RS256"];
@@ -40,7 +46,9 @@ export class JwtVerifier {
     );
   }
 
-  async verifyBearerToken(token: string | null): Promise<{ valid: boolean; reason?: string }> {
+  async verifyBearerToken(
+    token: string | null
+  ): Promise<{ valid: boolean; reason?: string; payload?: JWTPayload }> {
     if (token == null) {
       logger.warn("Bearer token verification failed: no token provided");
       return { valid: false, reason: "No bearer token provided" };
@@ -54,11 +62,11 @@ export class JwtVerifier {
         logger.warn({ reason }, "Bearer token verification failed");
         return { valid: false, reason };
       }
-      await jwtVerify(token, jwks, {
+      const { payload } = await jwtVerify(token, jwks, {
         issuer: iss,
         algorithms: ALLOWED_ALGORITHMS,
       });
-      return { valid: true };
+      return { valid: true, payload };
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error);
       logger.warn({ reason }, "Bearer token verification failed");

--- a/src/auth/mcpProjectResolver.test.ts
+++ b/src/auth/mcpProjectResolver.test.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2025 TomTom Navigation B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { McpProjectResolver } from "./mcpProjectResolver";
+
+const ACCOUNT_API = "https://account.test.example";
+const TOKEN = "test-account-token";
+
+const MCP_PRODUCT = { info: { code: "MCPServer", name: "MCP Server" } };
+const OTHER_PRODUCT = { info: { code: "OnlineMaps", name: "Map Display API" } };
+
+function mcpBundle(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    name: "Test Bundle",
+    type: "BUNDLE_TYPE_GENERIC",
+    isActive: true,
+    status: "BUNDLE_STATUS_ACTIVE",
+    products: [OTHER_PRODUCT, MCP_PRODUCT],
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+interface MockProject {
+  id: string;
+  bundles?: unknown[];
+  errorStatus?: number;
+}
+
+function stubAccountApi(projects: MockProject[]) {
+  const getProjectBodies: Array<Record<string, unknown>> = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const path = String(url).replace(ACCOUNT_API, "");
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      if (path === "/project.v2.ProjectService/ListProjects") {
+        return jsonResponse({ projects: projects.map(({ id }) => ({ id })) });
+      }
+      if (path === "/project.v2.ProjectService/GetProject") {
+        getProjectBodies.push(body);
+        const project = projects.find((p) => p.id === body.id);
+        if (project == null) return jsonResponse({ code: "not_found" }, 404);
+        if (project.errorStatus != null) {
+          return jsonResponse(
+            { code: "permission_denied", message: "permission denied" },
+            project.errorStatus
+          );
+        }
+        return jsonResponse({ project: { id: project.id, bundles: project.bundles } });
+      }
+      return jsonResponse({ code: "not_found" }, 404);
+    })
+  );
+  return getProjectBodies;
+}
+
+describe("McpProjectResolver", () => {
+  const resolver = new McpProjectResolver({ accountApiBaseUrl: ACCOUNT_API });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the first project whose active bundle contains the MCPServer product", async () => {
+    stubAccountApi([
+      { id: "project-1", bundles: [mcpBundle("bundle-1", { products: [OTHER_PRODUCT] })] },
+      { id: "project-2", bundles: [mcpBundle("bundle-2")] },
+      { id: "project-3", bundles: [mcpBundle("bundle-3")] },
+    ]);
+
+    await expect(resolver.resolveMcpProject(TOKEN)).resolves.toEqual({
+      projectId: "project-2",
+      bundleId: "bundle-2",
+    });
+  });
+
+  it("requests projects with with_products so bundles are populated", async () => {
+    const getProjectBodies = stubAccountApi([
+      { id: "project-1", bundles: [mcpBundle("bundle-1")] },
+    ]);
+
+    await resolver.resolveMcpProject(TOKEN);
+
+    expect(getProjectBodies).toEqual([{ id: "project-1", with_products: true }]);
+  });
+
+  it("ignores inactive bundles even when they contain the MCPServer product", async () => {
+    stubAccountApi([{ id: "project-1", bundles: [mcpBundle("bundle-1", { isActive: false })] }]);
+
+    await expect(resolver.resolveMcpProject(TOKEN)).resolves.toBeNull();
+  });
+
+  it("returns null when no bundle contains the MCPServer product", async () => {
+    stubAccountApi([
+      { id: "project-1", bundles: [mcpBundle("bundle-1", { products: [OTHER_PRODUCT] })] },
+      { id: "project-2", bundles: [] },
+    ]);
+
+    await expect(resolver.resolveMcpProject(TOKEN)).resolves.toBeNull();
+  });
+
+  it("returns null when the user has no projects", async () => {
+    stubAccountApi([]);
+
+    await expect(resolver.resolveMcpProject(TOKEN)).resolves.toBeNull();
+  });
+
+  it("skips projects that fail to load instead of throwing", async () => {
+    stubAccountApi([
+      { id: "project-1", errorStatus: 403 },
+      { id: "project-2", bundles: [mcpBundle("bundle-2")] },
+    ]);
+
+    await expect(resolver.resolveMcpProject(TOKEN)).resolves.toEqual({
+      projectId: "project-2",
+      bundleId: "bundle-2",
+    });
+  });
+});

--- a/src/auth/mcpProjectResolver.test.ts
+++ b/src/auth/mcpProjectResolver.test.ts
@@ -55,10 +55,10 @@ function stubAccountApi(projects: MockProject[]) {
     vi.fn(async (url: string | URL, init?: RequestInit) => {
       const path = String(url).replace(ACCOUNT_API, "");
       const body = JSON.parse(String(init?.body ?? "{}"));
-      if (path === "/project.v3.ProjectService/ListProjects") {
+      if (path === "/project.v2.ProjectService/ListProjects") {
         return jsonResponse({ projects: projects.map(({ id }) => ({ id })) });
       }
-      if (path === "/project.v3.ProjectService/GetProject") {
+      if (path === "/project.v2.ProjectService/GetProject") {
         getProjectBodies.push(body);
         const project = projects.find((p) => p.id === body.id);
         if (project == null) return jsonResponse({ code: "not_found" }, 404);

--- a/src/auth/mcpProjectResolver.test.ts
+++ b/src/auth/mcpProjectResolver.test.ts
@@ -55,10 +55,10 @@ function stubAccountApi(projects: MockProject[]) {
     vi.fn(async (url: string | URL, init?: RequestInit) => {
       const path = String(url).replace(ACCOUNT_API, "");
       const body = JSON.parse(String(init?.body ?? "{}"));
-      if (path === "/project.v2.ProjectService/ListProjects") {
+      if (path === "/project.v3.ProjectService/ListProjects") {
         return jsonResponse({ projects: projects.map(({ id }) => ({ id })) });
       }
-      if (path === "/project.v2.ProjectService/GetProject") {
+      if (path === "/project.v3.ProjectService/GetProject") {
         getProjectBodies.push(body);
         const project = projects.find((p) => p.id === body.id);
         if (project == null) return jsonResponse({ code: "not_found" }, 404);

--- a/src/auth/mcpProjectResolver.ts
+++ b/src/auth/mcpProjectResolver.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2025 TomTom Navigation B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { logger } from "../utils/logger";
+
+/** Product code marking a bundle as MCP-enabled (bundle type is BUNDLE_TYPE_GENERIC either way) */
+const MCP_PRODUCT_CODE = "MCPServer";
+
+export interface McpProjectResolverConfig {
+  /** Base URL for account/project endpoints (e.g. https://account.cx.tomtom.com) */
+  accountApiBaseUrl: string;
+}
+
+export interface McpProject {
+  projectId: string;
+  bundleId: string;
+}
+
+interface ProjectSummary {
+  id: string;
+  name?: string;
+}
+
+interface BundleProduct {
+  info?: {
+    code?: string;
+    name?: string;
+  };
+}
+
+interface Bundle {
+  id: string;
+  name?: string;
+  type?: string;
+  isActive?: boolean;
+  status?: string;
+  products?: BundleProduct[];
+}
+
+interface ProjectDetail {
+  id: string;
+  bundles?: Bundle[];
+}
+
+/**
+ * Finds the user's project whose bundle contains the MCP Server product, using
+ * the account gateway (Connect-go protocol):
+ * 1. ListProjects — returns project summaries only (project.v2.Summary has no bundles)
+ * 2. GetProject with with_products — populates project.bundles[].products
+ *
+ * The first project (in ListProjects order) with an active MCP-enabled bundle wins.
+ */
+export class McpProjectResolver {
+  private readonly accountApiBaseUrl: string;
+
+  constructor(config: McpProjectResolverConfig) {
+    this.accountApiBaseUrl = config.accountApiBaseUrl;
+  }
+
+  async resolveMcpProject(accountToken: string): Promise<McpProject | null> {
+    const projects = await this.listProjects(accountToken);
+    if (projects == null || projects.length === 0) {
+      logger.warn("No projects found for user");
+      return null;
+    }
+
+    for (const projectSummary of projects) {
+      const project = await this.getProjectWithProducts(accountToken, projectSummary.id);
+      const mcpBundle = project?.bundles?.find(
+        (bundle) =>
+          bundle.isActive &&
+          bundle.products?.some((product) => product.info?.code === MCP_PRODUCT_CODE)
+      );
+      if (mcpBundle != null) {
+        logger.debug(
+          { projectId: projectSummary.id, bundleId: mcpBundle.id },
+          "Resolved MCP project and bundle"
+        );
+        return { projectId: projectSummary.id, bundleId: mcpBundle.id };
+      }
+    }
+
+    logger.warn({ projectCount: projects.length }, "No project with an MCP bundle found for user");
+    return null;
+  }
+
+  private async listProjects(token: string): Promise<ProjectSummary[] | null> {
+    const response = await this.connectRequest<{ projects?: ProjectSummary[] }>(
+      token,
+      "/project.v2.ProjectService/ListProjects",
+      {}
+    );
+    return response?.projects ?? null;
+  }
+
+  private async getProjectWithProducts(
+    token: string,
+    projectId: string
+  ): Promise<ProjectDetail | null> {
+    const response = await this.connectRequest<{ project?: ProjectDetail }>(
+      token,
+      "/project.v2.ProjectService/GetProject",
+      { id: projectId, with_products: true }
+    );
+    return response?.project ?? null;
+  }
+
+  private async connectRequest<T>(
+    token: string,
+    path: string,
+    body: Record<string, unknown>
+  ): Promise<T | null> {
+    const url = `${this.accountApiBaseUrl}${path}`;
+    logger.debug({ url }, "Account API request");
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorBody = (await response.json().catch(() => null)) as {
+        code?: string;
+        message?: string;
+      } | null;
+      logger.error(
+        { status: response.status, url, code: errorBody?.code, message: errorBody?.message },
+        "Account API request failed"
+      );
+      return null;
+    }
+
+    return (await response.json()) as T;
+  }
+}

--- a/src/auth/mcpProjectResolver.ts
+++ b/src/auth/mcpProjectResolver.ts
@@ -41,12 +41,21 @@ interface BundleProduct {
   };
 }
 
+type BundleType =
+  | "BUNDLE_TYPE_UNSPECIFIED"
+  | "BUNDLE_TYPE_GENERIC"
+  | "BUNDLE_TYPE_SDK"
+  | "BUNDLE_TYPE_FEATURE";
+
+type BundleStatus = "BUNDLE_STATUS_UNSPECIFIED" | "BUNDLE_STATUS_ACTIVE" | "BUNDLE_STATUS_INACTIVE";
+
 interface Bundle {
   id: string;
   name?: string;
-  type?: string;
+  type?: BundleType;
+  /** Whether the bundle is currently active; only active bundles are treated as a match. */
   isActive?: boolean;
-  status?: string;
+  status?: BundleStatus;
   products?: BundleProduct[];
 }
 
@@ -58,7 +67,7 @@ interface ProjectDetail {
 /**
  * Finds the user's project whose bundle contains the MCP Server product, using
  * the account gateway (Connect-go protocol):
- * 1. ListProjects — returns project summaries only (project.v3.Summary has no bundles)
+ * 1. ListProjects — returns project summaries only (project.v2.Summary has no bundles)
  * 2. GetProject with with_products — populates project.bundles[].products
  *
  * The first project (in ListProjects order) with an active MCP-enabled bundle wins.
@@ -100,7 +109,7 @@ export class McpProjectResolver {
   private async listProjects(token: string): Promise<ProjectSummary[] | null> {
     const response = await this.connectRequest<{ projects?: ProjectSummary[] }>(
       token,
-      "/project.v3.ProjectService/ListProjects",
+      "/project.v2.ProjectService/ListProjects",
       {}
     );
     return response?.projects ?? null;
@@ -112,7 +121,7 @@ export class McpProjectResolver {
   ): Promise<ProjectDetail | null> {
     const response = await this.connectRequest<{ project?: ProjectDetail }>(
       token,
-      "/project.v3.ProjectService/GetProject",
+      "/project.v2.ProjectService/GetProject",
       { id: projectId, with_products: true }
     );
     return response?.project ?? null;

--- a/src/auth/mcpProjectResolver.ts
+++ b/src/auth/mcpProjectResolver.ts
@@ -58,7 +58,7 @@ interface ProjectDetail {
 /**
  * Finds the user's project whose bundle contains the MCP Server product, using
  * the account gateway (Connect-go protocol):
- * 1. ListProjects — returns project summaries only (project.v2.Summary has no bundles)
+ * 1. ListProjects — returns project summaries only (project.v3.Summary has no bundles)
  * 2. GetProject with with_products — populates project.bundles[].products
  *
  * The first project (in ListProjects order) with an active MCP-enabled bundle wins.
@@ -100,7 +100,7 @@ export class McpProjectResolver {
   private async listProjects(token: string): Promise<ProjectSummary[] | null> {
     const response = await this.connectRequest<{ projects?: ProjectSummary[] }>(
       token,
-      "/project.v2.ProjectService/ListProjects",
+      "/project.v3.ProjectService/ListProjects",
       {}
     );
     return response?.projects ?? null;
@@ -112,7 +112,7 @@ export class McpProjectResolver {
   ): Promise<ProjectDetail | null> {
     const response = await this.connectRequest<{ project?: ProjectDetail }>(
       token,
-      "/project.v2.ProjectService/GetProject",
+      "/project.v3.ProjectService/GetProject",
       { id: projectId, with_products: true }
     );
     return response?.project ?? null;

--- a/src/auth/tokenExchanger.test.ts
+++ b/src/auth/tokenExchanger.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2025 TomTom Navigation B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TokenExchanger } from "./tokenExchanger";
+
+const CONFIG = {
+  tokenEndpoint: "https://uls.test.example/token",
+  clientId: "https://mcp.test.example",
+  audience: "https://account.test.example",
+  scope: "authorize",
+};
+
+describe("TokenExchanger", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("posts an RFC 8693 token exchange request and returns the access token", async () => {
+    const mockFetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            access_token: "exchanged-token",
+            issued_token_type: "urn:ietf:params:oauth:token-type:jwt",
+            token_type: "Bearer",
+            expires_in: 3600,
+          }),
+          { status: 200 }
+        )
+    );
+    vi.stubGlobal("fetch", mockFetch);
+
+    const exchanger = new TokenExchanger(CONFIG);
+    await expect(exchanger.exchangeToken("user-token")).resolves.toBe("exchanged-token");
+
+    const [url, init] = mockFetch.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe(CONFIG.tokenEndpoint);
+    const params = new URLSearchParams(String(init.body));
+    expect(params.get("grant_type")).toBe("urn:ietf:params:oauth:grant-type:token-exchange");
+    expect(params.get("subject_token")).toBe("user-token");
+    expect(params.get("subject_token_type")).toBe("urn:ietf:params:oauth:token-type:jwt");
+    expect(params.get("requested_token_type")).toBe(
+      "urn:ietf:params:oauth:token-type:access_token"
+    );
+    expect(params.get("audience")).toBe(CONFIG.audience);
+    expect(params.get("scope")).toBe(CONFIG.scope);
+    expect(params.get("client_id")).toBe(CONFIG.clientId);
+  });
+
+  it("returns null on an OAuth error response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({ error: "invalid_grant", error_description: "expired subject token" }),
+            { status: 400 }
+          )
+      )
+    );
+
+    const exchanger = new TokenExchanger(CONFIG);
+    await expect(exchanger.exchangeToken("expired-token")).resolves.toBeNull();
+  });
+});

--- a/src/auth/tokenExchanger.ts
+++ b/src/auth/tokenExchanger.ts
@@ -15,18 +15,16 @@
  */
 
 import { logger } from "../utils/logger";
-import type { McpProject } from "./mcpProjectResolver";
 
-const PROJECT_SCOPE_PREFIX = "urn:tomtom:my:params:project:";
-const PRODUCT_BUNDLE_SCOPE_PREFIX = "urn:tomtom:my:params:product_bundle:";
-
-export interface UlsApiKeyResolverConfig {
-  /** ULS token endpoint URL (e.g. https://test.oauth.my.tomtom.com/token) */
-  ulsTokenEndpoint: string;
+export interface TokenExchangerConfig {
+  /** ULS token endpoint URL (e.g. https://oauth.my.tomtom.com/token) */
+  tokenEndpoint: string;
   /** Client ID identifying this app to ULS */
   clientId: string;
-  /** Target resource for the resolved API key */
-  resource: string;
+  /** Target audience for the exchanged token (e.g. https://account.cx.tomtom.com) */
+  audience: string;
+  /** Scope requested for the exchanged token (e.g. authorize) */
+  scope: string;
 }
 
 interface TokenExchangeResponse {
@@ -42,48 +40,44 @@ interface TokenExchangeErrorResponse {
 }
 
 /**
- * Resolves a TomTom API key by exchanging a user's JWT via the ULS token exchange endpoint.
+ * Exchanges a user's access token for one scoped to a different audience
+ * (e.g. the account management API) via the ULS token exchange endpoint.
  *
  * Uses RFC 8693 Token Exchange:
  * - grant_type: urn:ietf:params:oauth:grant-type:token-exchange
  * - subject_token_type: urn:ietf:params:oauth:token-type:jwt
- * - requested_token_type: urn:tomtom:uls:params:oauth:token-type:api_key
+ * - requested_token_type: urn:ietf:params:oauth:token-type:access_token
  */
-export class UlsApiKeyResolver {
-  private readonly ulsTokenEndpoint: string;
+export class TokenExchanger {
+  private readonly tokenEndpoint: string;
   private readonly clientId: string;
-  private readonly resource: string;
+  private readonly audience: string;
+  private readonly scope: string;
 
-  constructor(config: UlsApiKeyResolverConfig) {
-    this.ulsTokenEndpoint = config.ulsTokenEndpoint;
+  constructor(config: TokenExchangerConfig) {
+    this.tokenEndpoint = config.tokenEndpoint;
     this.clientId = config.clientId;
-    this.resource = config.resource;
+    this.audience = config.audience;
+    this.scope = config.scope;
   }
 
-  /**
-   * When mcpProject is given, the key is scoped to that project and product
-   * bundle via scope URNs; ULS verifies the user's write permission on the
-   * project and denies with access_denied otherwise.
-   */
-  async resolveApiKey(bearerToken: string, mcpProject?: McpProject): Promise<string | null> {
+  async exchangeToken(bearerToken: string): Promise<string | null> {
     const body = new URLSearchParams({
       grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
       subject_token: bearerToken,
       subject_token_type: "urn:ietf:params:oauth:token-type:jwt",
-      requested_token_type: "urn:tomtom:uls:params:oauth:token-type:api_key",
-      resource: this.resource,
+      requested_token_type: "urn:ietf:params:oauth:token-type:access_token",
+      audience: this.audience,
+      scope: this.scope,
       client_id: this.clientId,
     });
-    if (mcpProject != null) {
-      body.set(
-        "scope",
-        `${PROJECT_SCOPE_PREFIX}${mcpProject.projectId} ${PRODUCT_BUNDLE_SCOPE_PREFIX}${mcpProject.bundleId}`
-      );
-    }
 
-    logger.debug({ endpoint: this.ulsTokenEndpoint }, "ULS token exchange request");
+    logger.debug(
+      { endpoint: this.tokenEndpoint, audience: this.audience },
+      "Token exchange request"
+    );
 
-    const response = await fetch(this.ulsTokenEndpoint, {
+    const response = await fetch(this.tokenEndpoint, {
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
@@ -98,13 +92,15 @@ export class UlsApiKeyResolver {
       logger.error(
         {
           status: response.status,
+          audience: this.audience,
           error: errorBody?.error,
           errorDescription: errorBody?.error_description,
         },
-        "ULS token exchange failed"
+        "Token exchange failed"
       );
       return null;
     }
+
     const result = (await response.json()) as TokenExchangeResponse;
     return result.access_token ?? null;
   }

--- a/src/auth/ulsApiKeyResolver.test.ts
+++ b/src/auth/ulsApiKeyResolver.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2025 TomTom Navigation B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { UlsApiKeyResolver } from "./ulsApiKeyResolver";
+
+const CONFIG = {
+  ulsTokenEndpoint: "https://uls.test.example/token",
+  clientId: "https://mcp.test.example",
+  resource: "https://api.test.example",
+};
+
+function stubExchange(response: { body: unknown; status?: number }) {
+  const mockFetch = vi.fn(
+    async () => new Response(JSON.stringify(response.body), { status: response.status ?? 200 })
+  );
+  vi.stubGlobal("fetch", mockFetch);
+  return mockFetch;
+}
+
+function sentParams(mockFetch: ReturnType<typeof vi.fn>): URLSearchParams {
+  const [, init] = mockFetch.mock.calls[0] as unknown as [string, RequestInit];
+  return new URLSearchParams(String(init.body));
+}
+
+describe("UlsApiKeyResolver", () => {
+  const resolver = new UlsApiKeyResolver(CONFIG);
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("exchanges without a scope when no project is given", async () => {
+    const mockFetch = stubExchange({
+      body: {
+        access_token: "api-key-1",
+        issued_token_type: "urn:tomtom:uls:params:oauth:token-type:api_key",
+        token_type: "N_A",
+      },
+    });
+
+    await expect(resolver.resolveApiKey("user-token")).resolves.toBe("api-key-1");
+    expect(sentParams(mockFetch).get("scope")).toBeNull();
+  });
+
+  it("scopes the key to the project and product bundle via scope URNs", async () => {
+    const mockFetch = stubExchange({
+      body: {
+        access_token: "api-key-2",
+        issued_token_type: "urn:tomtom:uls:params:oauth:token-type:api_key",
+        token_type: "N_A",
+      },
+    });
+
+    await expect(
+      resolver.resolveApiKey("user-token", { projectId: "project-uuid", bundleId: "bundle-uuid" })
+    ).resolves.toBe("api-key-2");
+
+    expect(sentParams(mockFetch).get("scope")).toBe(
+      "urn:tomtom:my:params:project:project-uuid urn:tomtom:my:params:product_bundle:bundle-uuid"
+    );
+  });
+
+  it("returns null when ULS denies the scoped exchange", async () => {
+    stubExchange({
+      body: { error: "access_denied", error_description: "no write permission on project" },
+      status: 403,
+    });
+
+    await expect(
+      resolver.resolveApiKey("user-token", { projectId: "project-uuid", bundleId: "bundle-uuid" })
+    ).resolves.toBeNull();
+  });
+});

--- a/src/indexHttp.ts
+++ b/src/indexHttp.ts
@@ -34,6 +34,8 @@ import { registerErrorHandlers } from "./utils/uncaughtErrorHandlers";
 import { JwtVerifier } from "./auth/jwtVerifier";
 
 import { UlsApiKeyResolver } from "./auth/ulsApiKeyResolver";
+import { TokenExchanger } from "./auth/tokenExchanger";
+import { McpProjectResolver, type McpProject } from "./auth/mcpProjectResolver";
 
 registerErrorHandlers();
 
@@ -156,6 +158,17 @@ export async function createHttpServer(options: HttpServerOptions = {}): Promise
     resource: config.ulsResource,
   });
 
+  const tokenExchanger = new TokenExchanger({
+    tokenEndpoint: config.ulsTokenEndpoint,
+    clientId: config.ulsClientId,
+    audience: config.accountApiAudience,
+    scope: config.accountApiScope,
+  });
+
+  const mcpProjectResolver = new McpProjectResolver({
+    accountApiBaseUrl: config.accountApiBaseUrl,
+  });
+
   const app = express();
   app.use(express.json());
   app.use(
@@ -198,19 +211,30 @@ export async function createHttpServer(options: HttpServerOptions = {}): Promise
     const requestId = randomUUID();
     const apiKey = extractApiKey(req);
     try {
+      let mcpProject: McpProject | null = null;
       if (apiKey == null) {
         if (!oauthConfigured) {
           res.status(401).json({
             jsonrpc: "2.0",
-            error: { code: -32001, message: "Authentication required: provide a tomtom-api-key header or a Bearer token" },
+            error: {
+              code: -32001,
+              message: "Authentication required: provide a tomtom-api-key header or a Bearer token",
+            },
             id: req.body?.id || null,
           });
           return;
         }
-        const verification = await jwtVerifier!.verifyBearerToken(extractBearerToken(req));
+        const bearerToken = extractBearerToken(req);
+        const verification = await jwtVerifier!.verifyBearerToken(bearerToken);
         if (!verification.valid) {
           res
-            .set("WWW-Authenticate", buildWwwAuthenticate(resourceMetadataUrl, { error: "invalid_token", description: verification.reason }))
+            .set(
+              "WWW-Authenticate",
+              buildWwwAuthenticate(resourceMetadataUrl, {
+                error: "invalid_token",
+                description: verification.reason,
+              })
+            )
             .status(401)
             .json({
               jsonrpc: "2.0",
@@ -218,6 +242,19 @@ export async function createHttpServer(options: HttpServerOptions = {}): Promise
               id: req.body?.id || null,
             });
           return;
+        }
+        if (workforceTenantId != null && verification.payload?.tid === workforceTenantId) {
+          const accountToken = await tokenExchanger.exchangeToken(bearerToken!);
+          mcpProject =
+            accountToken != null ? await mcpProjectResolver.resolveMcpProject(accountToken) : null;
+          if (mcpProject != null) {
+            logger.info(
+              { requestId, projectId: mcpProject.projectId, bundleId: mcpProject.bundleId },
+              "Resolved MCP project for workforce user"
+            );
+          } else {
+            logger.warn({ requestId }, "MCP project resolution failed for workforce user");
+          }
         }
       }
 
@@ -245,7 +282,10 @@ export async function createHttpServer(options: HttpServerOptions = {}): Promise
       let resolvedApiKey = apiKey;
       if (resolvedApiKey == null) {
         const bearerToken = extractBearerToken(req)!;
-        resolvedApiKey = await ulsApiKeyResolver.resolveApiKey(bearerToken);
+        resolvedApiKey = await ulsApiKeyResolver.resolveApiKey(
+          bearerToken,
+          mcpProject ?? undefined
+        );
         if (resolvedApiKey == null) {
           res.status(502).json({
             jsonrpc: "2.0",
@@ -256,8 +296,8 @@ export async function createHttpServer(options: HttpServerOptions = {}): Promise
         }
       }
 
-      const authMethod = apiKey != null ? "tomtom-api-key" as const : "oauth" as const;
-      const metadata = JSON.stringify({ "auth_method":authMethod });
+      const authMethod = apiKey != null ? ("tomtom-api-key" as const) : ("oauth" as const);
+      const metadata = JSON.stringify({ auth_method: authMethod });
       res.setHeader("TomTom-Upstream-Metadata", Buffer.from(metadata).toString("base64"));
       await runWithSessionContext(resolvedApiKey, backend, async () => {
         await transport.handleRequest(req, res, req.body);
@@ -288,13 +328,16 @@ export async function createHttpServer(options: HttpServerOptions = {}): Promise
     });
   });
 
-  app.get(`/${ENDPOINT_OAUTH_PROTECTED_RESOURCE}${config.baseUrlPath}`, (_req: Request, res: Response) => {
-    res.json({
-      resource: `${config.baseUrl}${config.baseUrlPath}`,
-      authorization_servers: [authorizationServerUrl],
-      scopes_supported: SCOPES_SUPPORTED,
-    });
-  });
+  app.get(
+    `/${ENDPOINT_OAUTH_PROTECTED_RESOURCE}${config.baseUrlPath}`,
+    (_req: Request, res: Response) => {
+      res.json({
+        resource: `${config.baseUrl}${config.baseUrlPath}`,
+        authorization_servers: [authorizationServerUrl],
+        scopes_supported: SCOPES_SUPPORTED,
+      });
+    }
+  );
 
   const httpServer = app.listen(port, () => {
     logger.info(

--- a/veracode-pipeline-scan-baseline-file.json
+++ b/veracode-pipeline-scan-baseline-file.json
@@ -4,23 +4,434 @@
       "href": "/"
     },
     "self": {
-      "href": "/scans/abd5858a-f8af-491a-a7a3-9fbcef94458f/findings"
+      "href": "/scans/b419b362-bc65-4d9f-b699-428334879d55/findings"
     },
     "help": {
       "href": "https://docs.veracode.com/"
     }
   },
-  "scan_id": "abd5858a-f8af-491a-a7a3-9fbcef94458f",
+  "scan_id": "b419b362-bc65-4d9f-b699-428334879d55",
   "scan_status": "SUCCESS",
-  "message": "Scan successful. Results size: 12697 bytes",
+  "message": "Scan successful. Results size: 28863 bytes",
   "modules": [
-    "JS files within package.zip"
+    "JS files within package.zip",
+    "Python files within package.zip"
   ],
-  "modules_count": 1,
+  "modules_count": 2,
   "findings": [
     {
-      "title": "express.Response.json",
+      "title": "Node.appendChild",
+      "issue_id": 1001,
+      "image_path": "ui/src/sandbox.ts",
+      "gob": "B",
+      "severity": 3,
+      "issue_type_id": "taint",
+      "issue_type": "Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)",
+      "cwe_id": "80",
+      "exploit_level": "1",
+      "display_text": "\u003cspan\u003eThis call to Node.appendChild() contains a cross-site scripting (XSS) flaw.  The application populates the HTTP response with untrusted input, allowing an attacker to embed malicious content, such as Javascript code, which will be executed in the context of the victim\u0027s browser.  XSS vulnerabilities are commonly exploited to steal or manipulate cookies, modify presentation of content, and compromise confidential information, with new attack vectors being discovered on a regular basis. \u003c/span\u003e \u003cspan\u003eUse contextual escaping on all untrusted data before using it to construct any portion of an HTTP response.  The escaping method should be chosen based on the specific use case of the untrusted data, otherwise it may not protect fully against the attack. For example, if the data is being written to the body of an HTML page, use HTML entity escaping; if the data is being written to an attribute, use attribute escaping; etc.  Both the OWASP Java Encoder library and the Microsoft AntiXSS library provide contextual escaping methods. For more details on contextual escaping, see https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md. In addition, as a best practice, always validate untrusted input to ensure that it conforms to the expected format, using centralized data validation routines when possible.\u003c/span\u003e \u003cspan\u003eReferences: \u003ca href\u003d\"https://cwe.mitre.org/data/definitions/79.html\"\u003eCWE\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/www-community/attacks/xss/\"\u003eOWASP\u003c/a\u003e \u003ca href\u003d\"https://docs.veracode.com/r/review_cleansers\"\u003eSupported Cleansers\u003c/a\u003e\u003c/span\u003e",
+      "files": {
+        "source_file": {
+          "file": "ui/src/sandbox.ts",
+          "upload_file": "ui/src/sandbox.ts",
+          "line": 34,
+          "function_name": "!main",
+          "qualified_function_name": "!main",
+          "function_prototype": "!main() : void",
+          "scope": "UNKNOWN"
+        }
+      },
+      "flaw_match": {
+        "procedure_hash": "621454532",
+        "prototype_hash": "211846691",
+        "flaw_hash": "85533767",
+        "flaw_hash_count": 1,
+        "flaw_hash_ordinal": 1,
+        "cause_hash": "748381785",
+        "cause_hash_count": 1,
+        "cause_hash_ordinal": 1,
+        "cause_hash2": "1522093433",
+        "cause_hash2_ordinal": "4"
+      },
+      "stack_dumps": {
+        "stack_dump": [
+          {}
+        ]
+      },
+      "flaw_details_link": "https://downloads.veracode.com/securityscan/cwe/v4/java/80.html"
+    },
+    {
+      "title": "Document.write",
+      "issue_id": 1000,
+      "image_path": "ui/src/sandbox.ts",
+      "gob": "B",
+      "severity": 3,
+      "issue_type_id": "taint",
+      "issue_type": "Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)",
+      "cwe_id": "80",
+      "exploit_level": "1",
+      "display_text": "\u003cspan\u003eThis call to Document.write() contains a cross-site scripting (XSS) flaw.  The application populates the HTTP response with untrusted input, allowing an attacker to embed malicious content, such as Javascript code, which will be executed in the context of the victim\u0027s browser.  XSS vulnerabilities are commonly exploited to steal or manipulate cookies, modify presentation of content, and compromise confidential information, with new attack vectors being discovered on a regular basis. \u003c/span\u003e \u003cspan\u003eUse contextual escaping on all untrusted data before using it to construct any portion of an HTTP response.  The escaping method should be chosen based on the specific use case of the untrusted data, otherwise it may not protect fully against the attack. For example, if the data is being written to the body of an HTML page, use HTML entity escaping; if the data is being written to an attribute, use attribute escaping; etc.  Both the OWASP Java Encoder library and the Microsoft AntiXSS library provide contextual escaping methods. For more details on contextual escaping, see https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md. In addition, as a best practice, always validate untrusted input to ensure that it conforms to the expected format, using centralized data validation routines when possible.\u003c/span\u003e \u003cspan\u003eReferences: \u003ca href\u003d\"https://cwe.mitre.org/data/definitions/79.html\"\u003eCWE\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/www-community/attacks/xss/\"\u003eOWASP\u003c/a\u003e \u003ca href\u003d\"https://docs.veracode.com/r/review_cleansers\"\u003eSupported Cleansers\u003c/a\u003e\u003c/span\u003e",
+      "files": {
+        "source_file": {
+          "file": "ui/src/sandbox.ts",
+          "upload_file": "ui/src/sandbox.ts",
+          "line": 58,
+          "function_name": "lambda_1",
+          "qualified_function_name": "lambda_1",
+          "function_prototype": "lambda_1(: any,  : any, ...) : any",
+          "scope": "UNKNOWN"
+        }
+      },
+      "flaw_match": {
+        "procedure_hash": "1348005571",
+        "prototype_hash": "2002085674",
+        "flaw_hash": "2560374387",
+        "flaw_hash_count": 1,
+        "flaw_hash_ordinal": 1,
+        "cause_hash": "61553967",
+        "cause_hash_count": 1,
+        "cause_hash_ordinal": 1,
+        "cause_hash2": "1522093433",
+        "cause_hash2_ordinal": "5"
+      },
+      "stack_dumps": {
+        "stack_dump": [
+          {}
+        ]
+      },
+      "flaw_details_link": "https://downloads.veracode.com/securityscan/cwe/v4/java/80.html"
+    },
+    {
+      "title": "console.warn",
+      "issue_id": 1008,
+      "image_path": "ui/src/index.tsx",
+      "gob": "B",
+      "severity": 3,
+      "issue_type_id": "taint",
+      "issue_type": "Improper Output Neutralization for Logs",
+      "cwe_id": "117",
+      "exploit_level": "1",
+      "display_text": "\u003cspan\u003eThis call to console.warn() could result in a log forging attack.  Writing untrusted data into a log file allows an attacker to forge log entries or inject malicious content into log files.  Corrupted log files can be used to cover an attacker\u0027s tracks or as a delivery mechanism for an attack on a log viewing or processing utility.  For example, if a web administrator uses a browser-based utility to review logs, a cross-site scripting attack might be possible. \u003c/span\u003e \u003cspan\u003eAvoid directly embedding user input in log files when possible.  Sanitize untrusted data used to construct log entries by using a safe logging mechanism such as the OWASP ESAPI Logger, which will automatically remove unexpected carriage returns and line feeds and can be configured to use HTML entity encoding for non-alphanumeric data.  Alternatively, some of the XSS escaping functions from the OWASP Java Encoder project will also sanitize CRLF sequences.  Only create a custom blocklist when absolutely necessary.  Always validate untrusted input to ensure that it conforms to the expected format, using centralized data validation routines when possible.\u003c/span\u003e \u003cspan\u003eReferences: \u003ca href\u003d\"https://cwe.mitre.org/data/definitions/117.html\"\u003eCWE\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/www-community/attacks/Log_Injection\"\u003eOWASP\u003c/a\u003e \u003ca href\u003d\"https://docs.veracode.com/r/review_cleansers?tocId\u003dnYnZqAenFFZmB75MQrZwuA\"\u003eSupported Cleansers\u003c/a\u003e\u003c/span\u003e",
+      "files": {
+        "source_file": {
+          "file": "ui/src/index.tsx",
+          "upload_file": "ui/src/index.tsx",
+          "line": 1349,
+          "function_name": "connectToAllServers",
+          "qualified_function_name": "connectToAllServers",
+          "function_prototype": "connectToAllServers(: any, ...) : any",
+          "scope": "UNKNOWN"
+        }
+      },
+      "flaw_match": {
+        "procedure_hash": "4219556507",
+        "prototype_hash": "714316531",
+        "flaw_hash": "1691795182",
+        "flaw_hash_count": 1,
+        "flaw_hash_ordinal": 1,
+        "cause_hash": "4006399483",
+        "cause_hash_count": 1,
+        "cause_hash_ordinal": 1,
+        "cause_hash2": "448990436",
+        "cause_hash2_ordinal": "1"
+      },
+      "stack_dumps": {
+        "stack_dump": [
+          {}
+        ]
+      },
+      "flaw_details_link": "https://downloads.veracode.com/securityscan/cwe/v4/java/117.html"
+    },
+    {
+      "title": "console.info",
+      "issue_id": 1006,
+      "image_path": "ui/src/implementation.ts",
+      "gob": "B",
+      "severity": 3,
+      "issue_type_id": "taint",
+      "issue_type": "Improper Output Neutralization for Logs",
+      "cwe_id": "117",
+      "exploit_level": "1",
+      "display_text": "\u003cspan\u003eThis call to console.info() could result in a log forging attack.  Writing untrusted data into a log file allows an attacker to forge log entries or inject malicious content into log files.  Corrupted log files can be used to cover an attacker\u0027s tracks or as a delivery mechanism for an attack on a log viewing or processing utility.  For example, if a web administrator uses a browser-based utility to review logs, a cross-site scripting attack might be possible. \u003c/span\u003e \u003cspan\u003eAvoid directly embedding user input in log files when possible.  Sanitize untrusted data used to construct log entries by using a safe logging mechanism such as the OWASP ESAPI Logger, which will automatically remove unexpected carriage returns and line feeds and can be configured to use HTML entity encoding for non-alphanumeric data.  Alternatively, some of the XSS escaping functions from the OWASP Java Encoder project will also sanitize CRLF sequences.  Only create a custom blocklist when absolutely necessary.  Always validate untrusted input to ensure that it conforms to the expected format, using centralized data validation routines when possible.\u003c/span\u003e \u003cspan\u003eReferences: \u003ca href\u003d\"https://cwe.mitre.org/data/definitions/117.html\"\u003eCWE\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/www-community/attacks/Log_Injection\"\u003eOWASP\u003c/a\u003e \u003ca href\u003d\"https://docs.veracode.com/r/review_cleansers?tocId\u003dnYnZqAenFFZmB75MQrZwuA\"\u003eSupported Cleansers\u003c/a\u003e\u003c/span\u003e",
+      "files": {
+        "source_file": {
+          "file": "ui/src/implementation.ts",
+          "upload_file": "ui/src/implementation.ts",
+          "line": 48,
+          "function_name": "connectToServer",
+          "qualified_function_name": "connectToServer",
+          "function_prototype": "connectToServer(: any,  : URL,  : Record, ...) : any",
+          "scope": "UNKNOWN"
+        }
+      },
+      "flaw_match": {
+        "procedure_hash": "686891333",
+        "prototype_hash": "3486711632",
+        "flaw_hash": "2389351755",
+        "flaw_hash_count": 1,
+        "flaw_hash_ordinal": 1,
+        "cause_hash": "810508930",
+        "cause_hash_count": 1,
+        "cause_hash_ordinal": 1,
+        "cause_hash2": "438364638",
+        "cause_hash2_ordinal": "2"
+      },
+      "stack_dumps": {
+        "stack_dump": [
+          {}
+        ]
+      },
+      "flaw_details_link": "https://downloads.veracode.com/securityscan/cwe/v4/java/117.html"
+    },
+    {
+      "title": "console.log",
+      "issue_id": 1004,
+      "image_path": "ui/serve.ts",
+      "gob": "B",
+      "severity": 3,
+      "issue_type_id": "taint",
+      "issue_type": "Cleartext Storage of Sensitive Information",
+      "cwe_id": "312",
+      "exploit_level": "0",
+      "display_text": "\u003cspan\u003eThe console.log() method stores sensitive information in unencrypted form, making the data more susceptible to compromise. Generally an attacker needs local access to the system in order to exploit this type of flaw, but with mobile devices, files and other resources are often synchronized off the device to locations where they may be compromised through other means.\u003c/span\u003e \u003cspan\u003eStore all sensitive information in encrypted form.\u003c/span\u003e \u003cspan\u003eReferences: \u003ca href\u003d\"https://cwe.mitre.org/data/definitions/312.html\"\u003eCWE\u003c/a\u003e\u003c/span\u003e",
+      "files": {
+        "source_file": {
+          "file": "ui/serve.ts",
+          "upload_file": "ui/serve.ts",
+          "line": 119,
+          "function_name": "lambda_8",
+          "qualified_function_name": "lambda_8",
+          "function_prototype": "lambda_8(: any, ...) : any",
+          "scope": "UNKNOWN"
+        }
+      },
+      "flaw_match": {
+        "procedure_hash": "1215415",
+        "prototype_hash": "391610442",
+        "flaw_hash": "1339019146",
+        "flaw_hash_count": 1,
+        "flaw_hash_ordinal": 1,
+        "cause_hash": "2687568194",
+        "cause_hash_count": 1,
+        "cause_hash_ordinal": 1,
+        "cause_hash2": "2815333651",
+        "cause_hash2_ordinal": "1"
+      },
+      "stack_dumps": {
+        "stack_dump": [
+          {}
+        ]
+      },
+      "flaw_details_link": "https://downloads.veracode.com/securityscan/cwe/v4/java/312.html"
+    },
+    {
+      "title": "console.log",
+      "issue_id": 1003,
+      "image_path": "ui/serve.ts",
+      "gob": "B",
+      "severity": 3,
+      "issue_type_id": "taint",
+      "issue_type": "Cleartext Storage of Sensitive Information",
+      "cwe_id": "312",
+      "exploit_level": "0",
+      "display_text": "\u003cspan\u003eThe console.log() method stores sensitive information in unencrypted form, making the data more susceptible to compromise. Generally an attacker needs local access to the system in order to exploit this type of flaw, but with mobile devices, files and other resources are often synchronized off the device to locations where they may be compromised through other means.\u003c/span\u003e \u003cspan\u003eStore all sensitive information in encrypted form.\u003c/span\u003e \u003cspan\u003eReferences: \u003ca href\u003d\"https://cwe.mitre.org/data/definitions/312.html\"\u003eCWE\u003c/a\u003e\u003c/span\u003e",
+      "files": {
+        "source_file": {
+          "file": "ui/serve.ts",
+          "upload_file": "ui/serve.ts",
+          "line": 120,
+          "function_name": "lambda_8",
+          "qualified_function_name": "lambda_8",
+          "function_prototype": "lambda_8(: any, ...) : any",
+          "scope": "UNKNOWN"
+        }
+      },
+      "flaw_match": {
+        "procedure_hash": "1215415",
+        "prototype_hash": "391610442",
+        "flaw_hash": "2634349439",
+        "flaw_hash_count": 1,
+        "flaw_hash_ordinal": 1,
+        "cause_hash": "1899333690",
+        "cause_hash_count": 1,
+        "cause_hash_ordinal": 1,
+        "cause_hash2": "3040982730",
+        "cause_hash2_ordinal": "1"
+      },
+      "stack_dumps": {
+        "stack_dump": [
+          {}
+        ]
+      },
+      "flaw_details_link": "https://downloads.veracode.com/securityscan/cwe/v4/java/312.html"
+    },
+    {
+      "title": "console.log",
       "issue_id": 1005,
+      "image_path": "ui/serve.ts",
+      "gob": "B",
+      "severity": 3,
+      "issue_type_id": "taint",
+      "issue_type": "Cleartext Storage of Sensitive Information",
+      "cwe_id": "312",
+      "exploit_level": "0",
+      "display_text": "\u003cspan\u003eThe console.log() method stores sensitive information in unencrypted form, making the data more susceptible to compromise. Generally an attacker needs local access to the system in order to exploit this type of flaw, but with mobile devices, files and other resources are often synchronized off the device to locations where they may be compromised through other means.\u003c/span\u003e \u003cspan\u003eStore all sensitive information in encrypted form.\u003c/span\u003e \u003cspan\u003eReferences: \u003ca href\u003d\"https://cwe.mitre.org/data/definitions/312.html\"\u003eCWE\u003c/a\u003e\u003c/span\u003e",
+      "files": {
+        "source_file": {
+          "file": "ui/serve.ts",
+          "upload_file": "ui/serve.ts",
+          "line": 121,
+          "function_name": "lambda_8",
+          "qualified_function_name": "lambda_8",
+          "function_prototype": "lambda_8(: any, ...) : any",
+          "scope": "UNKNOWN"
+        }
+      },
+      "flaw_match": {
+        "procedure_hash": "1215415",
+        "prototype_hash": "391610442",
+        "flaw_hash": "841403916",
+        "flaw_hash_count": 1,
+        "flaw_hash_ordinal": 1,
+        "cause_hash": "727905817",
+        "cause_hash_count": 1,
+        "cause_hash_ordinal": 1,
+        "cause_hash2": "642850855",
+        "cause_hash2_ordinal": "1"
+      },
+      "stack_dumps": {
+        "stack_dump": [
+          {}
+        ]
+      },
+      "flaw_details_link": "https://downloads.veracode.com/securityscan/cwe/v4/java/312.html"
+    },
+    {
+      "title": "console.info",
+      "issue_id": 1007,
+      "image_path": "src/utils/logger.ts",
+      "gob": "B",
+      "severity": 3,
+      "issue_type_id": "taint",
+      "issue_type": "Improper Output Neutralization for Logs",
+      "cwe_id": "117",
+      "exploit_level": "1",
+      "display_text": "\u003cspan\u003eThis call to console.info() could result in a log forging attack.  Writing untrusted data into a log file allows an attacker to forge log entries or inject malicious content into log files.  Corrupted log files can be used to cover an attacker\u0027s tracks or as a delivery mechanism for an attack on a log viewing or processing utility.  For example, if a web administrator uses a browser-based utility to review logs, a cross-site scripting attack might be possible. \u003c/span\u003e \u003cspan\u003eAvoid directly embedding user input in log files when possible.  Sanitize untrusted data used to construct log entries by using a safe logging mechanism such as the OWASP ESAPI Logger, which will automatically remove unexpected carriage returns and line feeds and can be configured to use HTML entity encoding for non-alphanumeric data.  Alternatively, some of the XSS escaping functions from the OWASP Java Encoder project will also sanitize CRLF sequences.  Only create a custom blocklist when absolutely necessary.  Always validate untrusted input to ensure that it conforms to the expected format, using centralized data validation routines when possible.\u003c/span\u003e \u003cspan\u003eReferences: \u003ca href\u003d\"https://cwe.mitre.org/data/definitions/117.html\"\u003eCWE\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/www-community/attacks/Log_Injection\"\u003eOWASP\u003c/a\u003e \u003ca href\u003d\"https://docs.veracode.com/r/review_cleansers?tocId\u003dnYnZqAenFFZmB75MQrZwuA\"\u003eSupported Cleansers\u003c/a\u003e\u003c/span\u003e",
+      "files": {
+        "source_file": {
+          "file": "src/utils/logger.ts",
+          "upload_file": "src/utils/logger.ts",
+          "line": 66,
+          "function_name": "lambda_2",
+          "qualified_function_name": "lambda_2",
+          "function_prototype": "lambda_2(: any,  : any,  : String, ...) : any",
+          "scope": "UNKNOWN"
+        }
+      },
+      "flaw_match": {
+        "procedure_hash": "872111168",
+        "prototype_hash": "1594642372",
+        "flaw_hash": "104131697",
+        "flaw_hash_count": 1,
+        "flaw_hash_ordinal": 1,
+        "cause_hash": "2977876239",
+        "cause_hash_count": 1,
+        "cause_hash_ordinal": 1,
+        "cause_hash2": "1522093433",
+        "cause_hash2_ordinal": "6"
+      },
+      "stack_dumps": {
+        "stack_dump": [
+          {}
+        ]
+      },
+      "flaw_details_link": "https://downloads.veracode.com/securityscan/cwe/v4/java/117.html"
+    },
+    {
+      "title": "express.Response.json",
+      "issue_id": 1011,
+      "image_path": "ui/serve.ts",
+      "gob": "B",
+      "severity": 2,
+      "issue_type_id": "taint",
+      "issue_type": "Information Exposure Through Sent Data",
+      "cwe_id": "201",
+      "exploit_level": "-1",
+      "display_text": "\u003cspan\u003e The application calls the express.Response.json() function, which will result in data being transferred out of the application (via the network or another medium).  In this case, the message being sent appears to be considered private; this may include credentials such as usernames or passwords, data normally stored in cryptographically-protected vaults such as keychains, or other private information.  \u003c/span\u003e \u003cspan\u003eEnsure that the transfer of the sensitive data is intended and that it does not violate application security policy.  This flaw is categorized as low severity because it only impacts confidentiality, not integrity or availability.  However, in the context of a mobile application, the significance of an information leak may be much greater, especially if misaligned with user expectations or data privacy policies.\u003c/span\u003e \u003cspan\u003eReferences: \u003ca href\u003d\"https://cwe.mitre.org/data/definitions/201.html\"\u003eCWE\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/Top10/A05_2021-Security_Misconfiguration/\"\u003eOWASP Security Misconfiguration\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/Top10/A02_2021-Cryptographic_Failures/\"\u003eOWASP Cryptographic Failures\u003c/a\u003e\u003c/span\u003e",
+      "files": {
+        "source_file": {
+          "file": "ui/serve.ts",
+          "upload_file": "ui/serve.ts",
+          "line": 47,
+          "function_name": "lambda_2",
+          "qualified_function_name": "lambda_2",
+          "function_prototype": "lambda_2(: any,  : any,  : any, ...) : any",
+          "scope": "UNKNOWN"
+        }
+      },
+      "flaw_match": {
+        "procedure_hash": "3909136226",
+        "prototype_hash": "2210516080",
+        "flaw_hash": "2560374387",
+        "flaw_hash_count": 1,
+        "flaw_hash_ordinal": 1,
+        "cause_hash": "61553967",
+        "cause_hash_count": 1,
+        "cause_hash_ordinal": 1,
+        "cause_hash2": "1522093433",
+        "cause_hash2_ordinal": "5"
+      },
+      "stack_dumps": {
+        "stack_dump": [
+          {}
+        ]
+      },
+      "flaw_details_link": "https://downloads.veracode.com/securityscan/cwe/v4/java/201.html"
+    },
+    {
+      "title": "express.Response.json",
+      "issue_id": 1012,
+      "image_path": "ui/serve.ts",
+      "gob": "B",
+      "severity": 2,
+      "issue_type_id": "taint",
+      "issue_type": "Information Exposure Through Sent Data",
+      "cwe_id": "201",
+      "exploit_level": "-1",
+      "display_text": "\u003cspan\u003e The application calls the express.Response.json() function, which will result in data being transferred out of the application (via the network or another medium).  In this case, the message being sent appears to be considered private; this may include credentials such as usernames or passwords, data normally stored in cryptographically-protected vaults such as keychains, or other private information.  \u003c/span\u003e \u003cspan\u003eEnsure that the transfer of the sensitive data is intended and that it does not violate application security policy.  This flaw is categorized as low severity because it only impacts confidentiality, not integrity or availability.  However, in the context of a mobile application, the significance of an information leak may be much greater, especially if misaligned with user expectations or data privacy policies.\u003c/span\u003e \u003cspan\u003eReferences: \u003ca href\u003d\"https://cwe.mitre.org/data/definitions/201.html\"\u003eCWE\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/Top10/A05_2021-Security_Misconfiguration/\"\u003eOWASP Security Misconfiguration\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/Top10/A02_2021-Cryptographic_Failures/\"\u003eOWASP Cryptographic Failures\u003c/a\u003e\u003c/span\u003e",
+      "files": {
+        "source_file": {
+          "file": "ui/serve.ts",
+          "upload_file": "ui/serve.ts",
+          "line": 52,
+          "function_name": "lambda_3",
+          "qualified_function_name": "lambda_3",
+          "function_prototype": "lambda_3(: any,  : any,  : any, ...) : any",
+          "scope": "UNKNOWN"
+        }
+      },
+      "flaw_match": {
+        "procedure_hash": "2754444047",
+        "prototype_hash": "3575297392",
+        "flaw_hash": "2560374387",
+        "flaw_hash_count": 1,
+        "flaw_hash_ordinal": 1,
+        "cause_hash": "61553967",
+        "cause_hash_count": 1,
+        "cause_hash_ordinal": 1,
+        "cause_hash2": "1522093433",
+        "cause_hash2_ordinal": "5"
+      },
+      "stack_dumps": {
+        "stack_dump": [
+          {}
+        ]
+      },
+      "flaw_details_link": "https://downloads.veracode.com/securityscan/cwe/v4/java/201.html"
+    },
+    {
+      "title": "express.Response.json",
+      "issue_id": 1013,
       "image_path": "src/indexHttp.ts",
       "gob": "B",
       "severity": 2,
@@ -33,7 +444,7 @@
         "source_file": {
           "file": "src/indexHttp.ts",
           "upload_file": "src/indexHttp.ts",
-          "line": 263,
+          "line": 226,
           "function_name": "lambda_3",
           "qualified_function_name": "lambda_3",
           "function_prototype": "lambda_3(: any,  : express::Request,  : express::Response, ...) : any",
@@ -41,7 +452,7 @@
         }
       },
       "flaw_match": {
-        "procedure_hash": "1638220942",
+        "procedure_hash": "4150286391",
         "prototype_hash": "241343047",
         "flaw_hash": "3132762339",
         "flaw_hash_count": 5,
@@ -61,7 +472,7 @@
     },
     {
       "title": "express.Response.json",
-      "issue_id": 1003,
+      "issue_id": 1009,
       "image_path": "src/indexHttp.ts",
       "gob": "B",
       "severity": 2,
@@ -74,7 +485,7 @@
         "source_file": {
           "file": "src/indexHttp.ts",
           "upload_file": "src/indexHttp.ts",
-          "line": 322,
+          "line": 282,
           "function_name": "lambda_5",
           "qualified_function_name": "lambda_5",
           "function_prototype": "lambda_5(: any,  : express::Request,  : express::Response, ...) : any",
@@ -102,7 +513,7 @@
     },
     {
       "title": "express.Response.json",
-      "issue_id": 1004,
+      "issue_id": 1010,
       "image_path": "src/indexHttp.ts",
       "gob": "B",
       "severity": 2,
@@ -115,7 +526,7 @@
         "source_file": {
           "file": "src/indexHttp.ts",
           "upload_file": "src/indexHttp.ts",
-          "line": 334,
+          "line": 292,
           "function_name": "lambda_6",
           "qualified_function_name": "lambda_6",
           "function_prototype": "lambda_6(: any,  : express::Request,  : express::Response, ...) : any",
@@ -156,16 +567,16 @@
         "source_file": {
           "file": "src/auth/ulsApiKeyResolver.ts",
           "upload_file": "src/auth/ulsApiKeyResolver.ts",
-          "line": 86,
+          "line": 71,
           "function_name": "resolveApiKey",
           "qualified_function_name": "UlsApiKeyResolver.resolveApiKey",
-          "function_prototype": "resolveApiKey(: ::UlsApiKeyResolver,  : String,  : McpProject, ...) : any",
+          "function_prototype": "resolveApiKey(: ::UlsApiKeyResolver,  : String, ...) : any",
           "scope": "^::UlsApiKeyResolver"
         }
       },
       "flaw_match": {
-        "procedure_hash": "1911942594",
-        "prototype_hash": "1838136635",
+        "procedure_hash": "3871525075",
+        "prototype_hash": "3780001097",
         "flaw_hash": "1571468931",
         "flaw_hash_count": 1,
         "flaw_hash_ordinal": 1,
@@ -174,88 +585,6 @@
         "cause_hash_ordinal": 1,
         "cause_hash2": "438364638",
         "cause_hash2_ordinal": "1"
-      },
-      "stack_dumps": {
-        "stack_dump": [
-          {}
-        ]
-      },
-      "flaw_details_link": "https://downloads.veracode.com/securityscan/cwe/v4/java/201.html"
-    },
-    {
-      "title": "fetch",
-      "issue_id": 1001,
-      "image_path": "src/auth/tokenExchanger.ts",
-      "gob": "B",
-      "severity": 2,
-      "issue_type_id": "taint",
-      "issue_type": "Information Exposure Through Sent Data",
-      "cwe_id": "201",
-      "exploit_level": "-1",
-      "display_text": "\u003cspan\u003e The application calls the fetch() function, which will result in data being transferred out of the application (via the network or another medium).  In this case, the message being sent appears to be considered private; this may include credentials such as usernames or passwords, data normally stored in cryptographically-protected vaults such as keychains, or other private information.  \u003c/span\u003e \u003cspan\u003eEnsure that the transfer of the sensitive data is intended and that it does not violate application security policy.  This flaw is categorized as low severity because it only impacts confidentiality, not integrity or availability.  However, in the context of a mobile application, the significance of an information leak may be much greater, especially if misaligned with user expectations or data privacy policies.\u003c/span\u003e \u003cspan\u003eReferences: \u003ca href\u003d\"https://cwe.mitre.org/data/definitions/201.html\"\u003eCWE\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/Top10/A05_2021-Security_Misconfiguration/\"\u003eOWASP Security Misconfiguration\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/Top10/A02_2021-Cryptographic_Failures/\"\u003eOWASP Cryptographic Failures\u003c/a\u003e\u003c/span\u003e",
-      "files": {
-        "source_file": {
-          "file": "src/auth/tokenExchanger.ts",
-          "upload_file": "src/auth/tokenExchanger.ts",
-          "line": 80,
-          "function_name": "exchangeToken",
-          "qualified_function_name": "TokenExchanger.exchangeToken",
-          "function_prototype": "exchangeToken(: ::TokenExchanger,  : String, ...) : any",
-          "scope": "^::TokenExchanger"
-        }
-      },
-      "flaw_match": {
-        "procedure_hash": "3594801488",
-        "prototype_hash": "541915429",
-        "flaw_hash": "1571468931",
-        "flaw_hash_count": 1,
-        "flaw_hash_ordinal": 1,
-        "cause_hash": "2755370418",
-        "cause_hash_count": 1,
-        "cause_hash_ordinal": 1,
-        "cause_hash2": "438364638",
-        "cause_hash2_ordinal": "1"
-      },
-      "stack_dumps": {
-        "stack_dump": [
-          {}
-        ]
-      },
-      "flaw_details_link": "https://downloads.veracode.com/securityscan/cwe/v4/java/201.html"
-    },
-    {
-      "title": "fetch",
-      "issue_id": 1000,
-      "image_path": "src/auth/mcpProjectResolver.ts",
-      "gob": "B",
-      "severity": 2,
-      "issue_type_id": "taint",
-      "issue_type": "Information Exposure Through Sent Data",
-      "cwe_id": "201",
-      "exploit_level": "-1",
-      "display_text": "\u003cspan\u003e The application calls the fetch() function, which will result in data being transferred out of the application (via the network or another medium).  In this case, the message being sent appears to be considered private; this may include credentials such as usernames or passwords, data normally stored in cryptographically-protected vaults such as keychains, or other private information.  \u003c/span\u003e \u003cspan\u003eEnsure that the transfer of the sensitive data is intended and that it does not violate application security policy.  This flaw is categorized as low severity because it only impacts confidentiality, not integrity or availability.  However, in the context of a mobile application, the significance of an information leak may be much greater, especially if misaligned with user expectations or data privacy policies.\u003c/span\u003e \u003cspan\u003eReferences: \u003ca href\u003d\"https://cwe.mitre.org/data/definitions/201.html\"\u003eCWE\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/Top10/A05_2021-Security_Misconfiguration/\"\u003eOWASP Security Misconfiguration\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/Top10/A02_2021-Cryptographic_Failures/\"\u003eOWASP Cryptographic Failures\u003c/a\u003e\u003c/span\u003e",
-      "files": {
-        "source_file": {
-          "file": "src/auth/mcpProjectResolver.ts",
-          "upload_file": "src/auth/mcpProjectResolver.ts",
-          "line": 138,
-          "function_name": "connectRequest",
-          "qualified_function_name": "McpProjectResolver.connectRequest",
-          "function_prototype": "connectRequest(: ::McpProjectResolver,  : String,  : String,  : Record, ...) : any",
-          "scope": "^::McpProjectResolver"
-        }
-      },
-      "flaw_match": {
-        "procedure_hash": "3985807880",
-        "prototype_hash": "2171171610",
-        "flaw_hash": "55982450",
-        "flaw_hash_count": 1,
-        "flaw_hash_ordinal": 1,
-        "cause_hash": "1607772930",
-        "cause_hash_count": 1,
-        "cause_hash_ordinal": 1,
-        "cause_hash2": "1522093433",
-        "cause_hash2_ordinal": "6"
       },
       "stack_dumps": {
         "stack_dump": [
@@ -266,7 +595,7 @@
     }
   ],
   "selected_modules": [],
-  "engine_version": "20260806120029",
-  "pipeline_scan": "26.7.0-0",
+  "engine_version": "20260622142855",
+  "pipeline_scan": "26.3.0-0",
   "dev_stage": "DEVELOPMENT"
 }

--- a/veracode-pipeline-scan-baseline-file.json
+++ b/veracode-pipeline-scan-baseline-file.json
@@ -4,434 +4,23 @@
       "href": "/"
     },
     "self": {
-      "href": "/scans/b419b362-bc65-4d9f-b699-428334879d55/findings"
+      "href": "/scans/abd5858a-f8af-491a-a7a3-9fbcef94458f/findings"
     },
     "help": {
       "href": "https://docs.veracode.com/"
     }
   },
-  "scan_id": "b419b362-bc65-4d9f-b699-428334879d55",
+  "scan_id": "abd5858a-f8af-491a-a7a3-9fbcef94458f",
   "scan_status": "SUCCESS",
-  "message": "Scan successful. Results size: 28863 bytes",
+  "message": "Scan successful. Results size: 12697 bytes",
   "modules": [
-    "JS files within package.zip",
-    "Python files within package.zip"
+    "JS files within package.zip"
   ],
-  "modules_count": 2,
+  "modules_count": 1,
   "findings": [
     {
-      "title": "Node.appendChild",
-      "issue_id": 1001,
-      "image_path": "ui/src/sandbox.ts",
-      "gob": "B",
-      "severity": 3,
-      "issue_type_id": "taint",
-      "issue_type": "Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)",
-      "cwe_id": "80",
-      "exploit_level": "1",
-      "display_text": "\u003cspan\u003eThis call to Node.appendChild() contains a cross-site scripting (XSS) flaw.  The application populates the HTTP response with untrusted input, allowing an attacker to embed malicious content, such as Javascript code, which will be executed in the context of the victim\u0027s browser.  XSS vulnerabilities are commonly exploited to steal or manipulate cookies, modify presentation of content, and compromise confidential information, with new attack vectors being discovered on a regular basis. \u003c/span\u003e \u003cspan\u003eUse contextual escaping on all untrusted data before using it to construct any portion of an HTTP response.  The escaping method should be chosen based on the specific use case of the untrusted data, otherwise it may not protect fully against the attack. For example, if the data is being written to the body of an HTML page, use HTML entity escaping; if the data is being written to an attribute, use attribute escaping; etc.  Both the OWASP Java Encoder library and the Microsoft AntiXSS library provide contextual escaping methods. For more details on contextual escaping, see https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md. In addition, as a best practice, always validate untrusted input to ensure that it conforms to the expected format, using centralized data validation routines when possible.\u003c/span\u003e \u003cspan\u003eReferences: \u003ca href\u003d\"https://cwe.mitre.org/data/definitions/79.html\"\u003eCWE\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/www-community/attacks/xss/\"\u003eOWASP\u003c/a\u003e \u003ca href\u003d\"https://docs.veracode.com/r/review_cleansers\"\u003eSupported Cleansers\u003c/a\u003e\u003c/span\u003e",
-      "files": {
-        "source_file": {
-          "file": "ui/src/sandbox.ts",
-          "upload_file": "ui/src/sandbox.ts",
-          "line": 34,
-          "function_name": "!main",
-          "qualified_function_name": "!main",
-          "function_prototype": "!main() : void",
-          "scope": "UNKNOWN"
-        }
-      },
-      "flaw_match": {
-        "procedure_hash": "621454532",
-        "prototype_hash": "211846691",
-        "flaw_hash": "85533767",
-        "flaw_hash_count": 1,
-        "flaw_hash_ordinal": 1,
-        "cause_hash": "748381785",
-        "cause_hash_count": 1,
-        "cause_hash_ordinal": 1,
-        "cause_hash2": "1522093433",
-        "cause_hash2_ordinal": "4"
-      },
-      "stack_dumps": {
-        "stack_dump": [
-          {}
-        ]
-      },
-      "flaw_details_link": "https://downloads.veracode.com/securityscan/cwe/v4/java/80.html"
-    },
-    {
-      "title": "Document.write",
-      "issue_id": 1000,
-      "image_path": "ui/src/sandbox.ts",
-      "gob": "B",
-      "severity": 3,
-      "issue_type_id": "taint",
-      "issue_type": "Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)",
-      "cwe_id": "80",
-      "exploit_level": "1",
-      "display_text": "\u003cspan\u003eThis call to Document.write() contains a cross-site scripting (XSS) flaw.  The application populates the HTTP response with untrusted input, allowing an attacker to embed malicious content, such as Javascript code, which will be executed in the context of the victim\u0027s browser.  XSS vulnerabilities are commonly exploited to steal or manipulate cookies, modify presentation of content, and compromise confidential information, with new attack vectors being discovered on a regular basis. \u003c/span\u003e \u003cspan\u003eUse contextual escaping on all untrusted data before using it to construct any portion of an HTTP response.  The escaping method should be chosen based on the specific use case of the untrusted data, otherwise it may not protect fully against the attack. For example, if the data is being written to the body of an HTML page, use HTML entity escaping; if the data is being written to an attribute, use attribute escaping; etc.  Both the OWASP Java Encoder library and the Microsoft AntiXSS library provide contextual escaping methods. For more details on contextual escaping, see https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md. In addition, as a best practice, always validate untrusted input to ensure that it conforms to the expected format, using centralized data validation routines when possible.\u003c/span\u003e \u003cspan\u003eReferences: \u003ca href\u003d\"https://cwe.mitre.org/data/definitions/79.html\"\u003eCWE\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/www-community/attacks/xss/\"\u003eOWASP\u003c/a\u003e \u003ca href\u003d\"https://docs.veracode.com/r/review_cleansers\"\u003eSupported Cleansers\u003c/a\u003e\u003c/span\u003e",
-      "files": {
-        "source_file": {
-          "file": "ui/src/sandbox.ts",
-          "upload_file": "ui/src/sandbox.ts",
-          "line": 58,
-          "function_name": "lambda_1",
-          "qualified_function_name": "lambda_1",
-          "function_prototype": "lambda_1(: any,  : any, ...) : any",
-          "scope": "UNKNOWN"
-        }
-      },
-      "flaw_match": {
-        "procedure_hash": "1348005571",
-        "prototype_hash": "2002085674",
-        "flaw_hash": "2560374387",
-        "flaw_hash_count": 1,
-        "flaw_hash_ordinal": 1,
-        "cause_hash": "61553967",
-        "cause_hash_count": 1,
-        "cause_hash_ordinal": 1,
-        "cause_hash2": "1522093433",
-        "cause_hash2_ordinal": "5"
-      },
-      "stack_dumps": {
-        "stack_dump": [
-          {}
-        ]
-      },
-      "flaw_details_link": "https://downloads.veracode.com/securityscan/cwe/v4/java/80.html"
-    },
-    {
-      "title": "console.warn",
-      "issue_id": 1008,
-      "image_path": "ui/src/index.tsx",
-      "gob": "B",
-      "severity": 3,
-      "issue_type_id": "taint",
-      "issue_type": "Improper Output Neutralization for Logs",
-      "cwe_id": "117",
-      "exploit_level": "1",
-      "display_text": "\u003cspan\u003eThis call to console.warn() could result in a log forging attack.  Writing untrusted data into a log file allows an attacker to forge log entries or inject malicious content into log files.  Corrupted log files can be used to cover an attacker\u0027s tracks or as a delivery mechanism for an attack on a log viewing or processing utility.  For example, if a web administrator uses a browser-based utility to review logs, a cross-site scripting attack might be possible. \u003c/span\u003e \u003cspan\u003eAvoid directly embedding user input in log files when possible.  Sanitize untrusted data used to construct log entries by using a safe logging mechanism such as the OWASP ESAPI Logger, which will automatically remove unexpected carriage returns and line feeds and can be configured to use HTML entity encoding for non-alphanumeric data.  Alternatively, some of the XSS escaping functions from the OWASP Java Encoder project will also sanitize CRLF sequences.  Only create a custom blocklist when absolutely necessary.  Always validate untrusted input to ensure that it conforms to the expected format, using centralized data validation routines when possible.\u003c/span\u003e \u003cspan\u003eReferences: \u003ca href\u003d\"https://cwe.mitre.org/data/definitions/117.html\"\u003eCWE\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/www-community/attacks/Log_Injection\"\u003eOWASP\u003c/a\u003e \u003ca href\u003d\"https://docs.veracode.com/r/review_cleansers?tocId\u003dnYnZqAenFFZmB75MQrZwuA\"\u003eSupported Cleansers\u003c/a\u003e\u003c/span\u003e",
-      "files": {
-        "source_file": {
-          "file": "ui/src/index.tsx",
-          "upload_file": "ui/src/index.tsx",
-          "line": 1349,
-          "function_name": "connectToAllServers",
-          "qualified_function_name": "connectToAllServers",
-          "function_prototype": "connectToAllServers(: any, ...) : any",
-          "scope": "UNKNOWN"
-        }
-      },
-      "flaw_match": {
-        "procedure_hash": "4219556507",
-        "prototype_hash": "714316531",
-        "flaw_hash": "1691795182",
-        "flaw_hash_count": 1,
-        "flaw_hash_ordinal": 1,
-        "cause_hash": "4006399483",
-        "cause_hash_count": 1,
-        "cause_hash_ordinal": 1,
-        "cause_hash2": "448990436",
-        "cause_hash2_ordinal": "1"
-      },
-      "stack_dumps": {
-        "stack_dump": [
-          {}
-        ]
-      },
-      "flaw_details_link": "https://downloads.veracode.com/securityscan/cwe/v4/java/117.html"
-    },
-    {
-      "title": "console.info",
-      "issue_id": 1006,
-      "image_path": "ui/src/implementation.ts",
-      "gob": "B",
-      "severity": 3,
-      "issue_type_id": "taint",
-      "issue_type": "Improper Output Neutralization for Logs",
-      "cwe_id": "117",
-      "exploit_level": "1",
-      "display_text": "\u003cspan\u003eThis call to console.info() could result in a log forging attack.  Writing untrusted data into a log file allows an attacker to forge log entries or inject malicious content into log files.  Corrupted log files can be used to cover an attacker\u0027s tracks or as a delivery mechanism for an attack on a log viewing or processing utility.  For example, if a web administrator uses a browser-based utility to review logs, a cross-site scripting attack might be possible. \u003c/span\u003e \u003cspan\u003eAvoid directly embedding user input in log files when possible.  Sanitize untrusted data used to construct log entries by using a safe logging mechanism such as the OWASP ESAPI Logger, which will automatically remove unexpected carriage returns and line feeds and can be configured to use HTML entity encoding for non-alphanumeric data.  Alternatively, some of the XSS escaping functions from the OWASP Java Encoder project will also sanitize CRLF sequences.  Only create a custom blocklist when absolutely necessary.  Always validate untrusted input to ensure that it conforms to the expected format, using centralized data validation routines when possible.\u003c/span\u003e \u003cspan\u003eReferences: \u003ca href\u003d\"https://cwe.mitre.org/data/definitions/117.html\"\u003eCWE\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/www-community/attacks/Log_Injection\"\u003eOWASP\u003c/a\u003e \u003ca href\u003d\"https://docs.veracode.com/r/review_cleansers?tocId\u003dnYnZqAenFFZmB75MQrZwuA\"\u003eSupported Cleansers\u003c/a\u003e\u003c/span\u003e",
-      "files": {
-        "source_file": {
-          "file": "ui/src/implementation.ts",
-          "upload_file": "ui/src/implementation.ts",
-          "line": 48,
-          "function_name": "connectToServer",
-          "qualified_function_name": "connectToServer",
-          "function_prototype": "connectToServer(: any,  : URL,  : Record, ...) : any",
-          "scope": "UNKNOWN"
-        }
-      },
-      "flaw_match": {
-        "procedure_hash": "686891333",
-        "prototype_hash": "3486711632",
-        "flaw_hash": "2389351755",
-        "flaw_hash_count": 1,
-        "flaw_hash_ordinal": 1,
-        "cause_hash": "810508930",
-        "cause_hash_count": 1,
-        "cause_hash_ordinal": 1,
-        "cause_hash2": "438364638",
-        "cause_hash2_ordinal": "2"
-      },
-      "stack_dumps": {
-        "stack_dump": [
-          {}
-        ]
-      },
-      "flaw_details_link": "https://downloads.veracode.com/securityscan/cwe/v4/java/117.html"
-    },
-    {
-      "title": "console.log",
-      "issue_id": 1004,
-      "image_path": "ui/serve.ts",
-      "gob": "B",
-      "severity": 3,
-      "issue_type_id": "taint",
-      "issue_type": "Cleartext Storage of Sensitive Information",
-      "cwe_id": "312",
-      "exploit_level": "0",
-      "display_text": "\u003cspan\u003eThe console.log() method stores sensitive information in unencrypted form, making the data more susceptible to compromise. Generally an attacker needs local access to the system in order to exploit this type of flaw, but with mobile devices, files and other resources are often synchronized off the device to locations where they may be compromised through other means.\u003c/span\u003e \u003cspan\u003eStore all sensitive information in encrypted form.\u003c/span\u003e \u003cspan\u003eReferences: \u003ca href\u003d\"https://cwe.mitre.org/data/definitions/312.html\"\u003eCWE\u003c/a\u003e\u003c/span\u003e",
-      "files": {
-        "source_file": {
-          "file": "ui/serve.ts",
-          "upload_file": "ui/serve.ts",
-          "line": 119,
-          "function_name": "lambda_8",
-          "qualified_function_name": "lambda_8",
-          "function_prototype": "lambda_8(: any, ...) : any",
-          "scope": "UNKNOWN"
-        }
-      },
-      "flaw_match": {
-        "procedure_hash": "1215415",
-        "prototype_hash": "391610442",
-        "flaw_hash": "1339019146",
-        "flaw_hash_count": 1,
-        "flaw_hash_ordinal": 1,
-        "cause_hash": "2687568194",
-        "cause_hash_count": 1,
-        "cause_hash_ordinal": 1,
-        "cause_hash2": "2815333651",
-        "cause_hash2_ordinal": "1"
-      },
-      "stack_dumps": {
-        "stack_dump": [
-          {}
-        ]
-      },
-      "flaw_details_link": "https://downloads.veracode.com/securityscan/cwe/v4/java/312.html"
-    },
-    {
-      "title": "console.log",
-      "issue_id": 1003,
-      "image_path": "ui/serve.ts",
-      "gob": "B",
-      "severity": 3,
-      "issue_type_id": "taint",
-      "issue_type": "Cleartext Storage of Sensitive Information",
-      "cwe_id": "312",
-      "exploit_level": "0",
-      "display_text": "\u003cspan\u003eThe console.log() method stores sensitive information in unencrypted form, making the data more susceptible to compromise. Generally an attacker needs local access to the system in order to exploit this type of flaw, but with mobile devices, files and other resources are often synchronized off the device to locations where they may be compromised through other means.\u003c/span\u003e \u003cspan\u003eStore all sensitive information in encrypted form.\u003c/span\u003e \u003cspan\u003eReferences: \u003ca href\u003d\"https://cwe.mitre.org/data/definitions/312.html\"\u003eCWE\u003c/a\u003e\u003c/span\u003e",
-      "files": {
-        "source_file": {
-          "file": "ui/serve.ts",
-          "upload_file": "ui/serve.ts",
-          "line": 120,
-          "function_name": "lambda_8",
-          "qualified_function_name": "lambda_8",
-          "function_prototype": "lambda_8(: any, ...) : any",
-          "scope": "UNKNOWN"
-        }
-      },
-      "flaw_match": {
-        "procedure_hash": "1215415",
-        "prototype_hash": "391610442",
-        "flaw_hash": "2634349439",
-        "flaw_hash_count": 1,
-        "flaw_hash_ordinal": 1,
-        "cause_hash": "1899333690",
-        "cause_hash_count": 1,
-        "cause_hash_ordinal": 1,
-        "cause_hash2": "3040982730",
-        "cause_hash2_ordinal": "1"
-      },
-      "stack_dumps": {
-        "stack_dump": [
-          {}
-        ]
-      },
-      "flaw_details_link": "https://downloads.veracode.com/securityscan/cwe/v4/java/312.html"
-    },
-    {
-      "title": "console.log",
+      "title": "express.Response.json",
       "issue_id": 1005,
-      "image_path": "ui/serve.ts",
-      "gob": "B",
-      "severity": 3,
-      "issue_type_id": "taint",
-      "issue_type": "Cleartext Storage of Sensitive Information",
-      "cwe_id": "312",
-      "exploit_level": "0",
-      "display_text": "\u003cspan\u003eThe console.log() method stores sensitive information in unencrypted form, making the data more susceptible to compromise. Generally an attacker needs local access to the system in order to exploit this type of flaw, but with mobile devices, files and other resources are often synchronized off the device to locations where they may be compromised through other means.\u003c/span\u003e \u003cspan\u003eStore all sensitive information in encrypted form.\u003c/span\u003e \u003cspan\u003eReferences: \u003ca href\u003d\"https://cwe.mitre.org/data/definitions/312.html\"\u003eCWE\u003c/a\u003e\u003c/span\u003e",
-      "files": {
-        "source_file": {
-          "file": "ui/serve.ts",
-          "upload_file": "ui/serve.ts",
-          "line": 121,
-          "function_name": "lambda_8",
-          "qualified_function_name": "lambda_8",
-          "function_prototype": "lambda_8(: any, ...) : any",
-          "scope": "UNKNOWN"
-        }
-      },
-      "flaw_match": {
-        "procedure_hash": "1215415",
-        "prototype_hash": "391610442",
-        "flaw_hash": "841403916",
-        "flaw_hash_count": 1,
-        "flaw_hash_ordinal": 1,
-        "cause_hash": "727905817",
-        "cause_hash_count": 1,
-        "cause_hash_ordinal": 1,
-        "cause_hash2": "642850855",
-        "cause_hash2_ordinal": "1"
-      },
-      "stack_dumps": {
-        "stack_dump": [
-          {}
-        ]
-      },
-      "flaw_details_link": "https://downloads.veracode.com/securityscan/cwe/v4/java/312.html"
-    },
-    {
-      "title": "console.info",
-      "issue_id": 1007,
-      "image_path": "src/utils/logger.ts",
-      "gob": "B",
-      "severity": 3,
-      "issue_type_id": "taint",
-      "issue_type": "Improper Output Neutralization for Logs",
-      "cwe_id": "117",
-      "exploit_level": "1",
-      "display_text": "\u003cspan\u003eThis call to console.info() could result in a log forging attack.  Writing untrusted data into a log file allows an attacker to forge log entries or inject malicious content into log files.  Corrupted log files can be used to cover an attacker\u0027s tracks or as a delivery mechanism for an attack on a log viewing or processing utility.  For example, if a web administrator uses a browser-based utility to review logs, a cross-site scripting attack might be possible. \u003c/span\u003e \u003cspan\u003eAvoid directly embedding user input in log files when possible.  Sanitize untrusted data used to construct log entries by using a safe logging mechanism such as the OWASP ESAPI Logger, which will automatically remove unexpected carriage returns and line feeds and can be configured to use HTML entity encoding for non-alphanumeric data.  Alternatively, some of the XSS escaping functions from the OWASP Java Encoder project will also sanitize CRLF sequences.  Only create a custom blocklist when absolutely necessary.  Always validate untrusted input to ensure that it conforms to the expected format, using centralized data validation routines when possible.\u003c/span\u003e \u003cspan\u003eReferences: \u003ca href\u003d\"https://cwe.mitre.org/data/definitions/117.html\"\u003eCWE\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/www-community/attacks/Log_Injection\"\u003eOWASP\u003c/a\u003e \u003ca href\u003d\"https://docs.veracode.com/r/review_cleansers?tocId\u003dnYnZqAenFFZmB75MQrZwuA\"\u003eSupported Cleansers\u003c/a\u003e\u003c/span\u003e",
-      "files": {
-        "source_file": {
-          "file": "src/utils/logger.ts",
-          "upload_file": "src/utils/logger.ts",
-          "line": 66,
-          "function_name": "lambda_2",
-          "qualified_function_name": "lambda_2",
-          "function_prototype": "lambda_2(: any,  : any,  : String, ...) : any",
-          "scope": "UNKNOWN"
-        }
-      },
-      "flaw_match": {
-        "procedure_hash": "872111168",
-        "prototype_hash": "1594642372",
-        "flaw_hash": "104131697",
-        "flaw_hash_count": 1,
-        "flaw_hash_ordinal": 1,
-        "cause_hash": "2977876239",
-        "cause_hash_count": 1,
-        "cause_hash_ordinal": 1,
-        "cause_hash2": "1522093433",
-        "cause_hash2_ordinal": "6"
-      },
-      "stack_dumps": {
-        "stack_dump": [
-          {}
-        ]
-      },
-      "flaw_details_link": "https://downloads.veracode.com/securityscan/cwe/v4/java/117.html"
-    },
-    {
-      "title": "express.Response.json",
-      "issue_id": 1011,
-      "image_path": "ui/serve.ts",
-      "gob": "B",
-      "severity": 2,
-      "issue_type_id": "taint",
-      "issue_type": "Information Exposure Through Sent Data",
-      "cwe_id": "201",
-      "exploit_level": "-1",
-      "display_text": "\u003cspan\u003e The application calls the express.Response.json() function, which will result in data being transferred out of the application (via the network or another medium).  In this case, the message being sent appears to be considered private; this may include credentials such as usernames or passwords, data normally stored in cryptographically-protected vaults such as keychains, or other private information.  \u003c/span\u003e \u003cspan\u003eEnsure that the transfer of the sensitive data is intended and that it does not violate application security policy.  This flaw is categorized as low severity because it only impacts confidentiality, not integrity or availability.  However, in the context of a mobile application, the significance of an information leak may be much greater, especially if misaligned with user expectations or data privacy policies.\u003c/span\u003e \u003cspan\u003eReferences: \u003ca href\u003d\"https://cwe.mitre.org/data/definitions/201.html\"\u003eCWE\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/Top10/A05_2021-Security_Misconfiguration/\"\u003eOWASP Security Misconfiguration\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/Top10/A02_2021-Cryptographic_Failures/\"\u003eOWASP Cryptographic Failures\u003c/a\u003e\u003c/span\u003e",
-      "files": {
-        "source_file": {
-          "file": "ui/serve.ts",
-          "upload_file": "ui/serve.ts",
-          "line": 47,
-          "function_name": "lambda_2",
-          "qualified_function_name": "lambda_2",
-          "function_prototype": "lambda_2(: any,  : any,  : any, ...) : any",
-          "scope": "UNKNOWN"
-        }
-      },
-      "flaw_match": {
-        "procedure_hash": "3909136226",
-        "prototype_hash": "2210516080",
-        "flaw_hash": "2560374387",
-        "flaw_hash_count": 1,
-        "flaw_hash_ordinal": 1,
-        "cause_hash": "61553967",
-        "cause_hash_count": 1,
-        "cause_hash_ordinal": 1,
-        "cause_hash2": "1522093433",
-        "cause_hash2_ordinal": "5"
-      },
-      "stack_dumps": {
-        "stack_dump": [
-          {}
-        ]
-      },
-      "flaw_details_link": "https://downloads.veracode.com/securityscan/cwe/v4/java/201.html"
-    },
-    {
-      "title": "express.Response.json",
-      "issue_id": 1012,
-      "image_path": "ui/serve.ts",
-      "gob": "B",
-      "severity": 2,
-      "issue_type_id": "taint",
-      "issue_type": "Information Exposure Through Sent Data",
-      "cwe_id": "201",
-      "exploit_level": "-1",
-      "display_text": "\u003cspan\u003e The application calls the express.Response.json() function, which will result in data being transferred out of the application (via the network or another medium).  In this case, the message being sent appears to be considered private; this may include credentials such as usernames or passwords, data normally stored in cryptographically-protected vaults such as keychains, or other private information.  \u003c/span\u003e \u003cspan\u003eEnsure that the transfer of the sensitive data is intended and that it does not violate application security policy.  This flaw is categorized as low severity because it only impacts confidentiality, not integrity or availability.  However, in the context of a mobile application, the significance of an information leak may be much greater, especially if misaligned with user expectations or data privacy policies.\u003c/span\u003e \u003cspan\u003eReferences: \u003ca href\u003d\"https://cwe.mitre.org/data/definitions/201.html\"\u003eCWE\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/Top10/A05_2021-Security_Misconfiguration/\"\u003eOWASP Security Misconfiguration\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/Top10/A02_2021-Cryptographic_Failures/\"\u003eOWASP Cryptographic Failures\u003c/a\u003e\u003c/span\u003e",
-      "files": {
-        "source_file": {
-          "file": "ui/serve.ts",
-          "upload_file": "ui/serve.ts",
-          "line": 52,
-          "function_name": "lambda_3",
-          "qualified_function_name": "lambda_3",
-          "function_prototype": "lambda_3(: any,  : any,  : any, ...) : any",
-          "scope": "UNKNOWN"
-        }
-      },
-      "flaw_match": {
-        "procedure_hash": "2754444047",
-        "prototype_hash": "3575297392",
-        "flaw_hash": "2560374387",
-        "flaw_hash_count": 1,
-        "flaw_hash_ordinal": 1,
-        "cause_hash": "61553967",
-        "cause_hash_count": 1,
-        "cause_hash_ordinal": 1,
-        "cause_hash2": "1522093433",
-        "cause_hash2_ordinal": "5"
-      },
-      "stack_dumps": {
-        "stack_dump": [
-          {}
-        ]
-      },
-      "flaw_details_link": "https://downloads.veracode.com/securityscan/cwe/v4/java/201.html"
-    },
-    {
-      "title": "express.Response.json",
-      "issue_id": 1013,
       "image_path": "src/indexHttp.ts",
       "gob": "B",
       "severity": 2,
@@ -444,7 +33,7 @@
         "source_file": {
           "file": "src/indexHttp.ts",
           "upload_file": "src/indexHttp.ts",
-          "line": 226,
+          "line": 263,
           "function_name": "lambda_3",
           "qualified_function_name": "lambda_3",
           "function_prototype": "lambda_3(: any,  : express::Request,  : express::Response, ...) : any",
@@ -452,7 +41,7 @@
         }
       },
       "flaw_match": {
-        "procedure_hash": "4150286391",
+        "procedure_hash": "1638220942",
         "prototype_hash": "241343047",
         "flaw_hash": "3132762339",
         "flaw_hash_count": 5,
@@ -472,7 +61,7 @@
     },
     {
       "title": "express.Response.json",
-      "issue_id": 1009,
+      "issue_id": 1003,
       "image_path": "src/indexHttp.ts",
       "gob": "B",
       "severity": 2,
@@ -485,7 +74,7 @@
         "source_file": {
           "file": "src/indexHttp.ts",
           "upload_file": "src/indexHttp.ts",
-          "line": 282,
+          "line": 322,
           "function_name": "lambda_5",
           "qualified_function_name": "lambda_5",
           "function_prototype": "lambda_5(: any,  : express::Request,  : express::Response, ...) : any",
@@ -513,7 +102,7 @@
     },
     {
       "title": "express.Response.json",
-      "issue_id": 1010,
+      "issue_id": 1004,
       "image_path": "src/indexHttp.ts",
       "gob": "B",
       "severity": 2,
@@ -526,7 +115,7 @@
         "source_file": {
           "file": "src/indexHttp.ts",
           "upload_file": "src/indexHttp.ts",
-          "line": 292,
+          "line": 334,
           "function_name": "lambda_6",
           "qualified_function_name": "lambda_6",
           "function_prototype": "lambda_6(: any,  : express::Request,  : express::Response, ...) : any",
@@ -567,16 +156,16 @@
         "source_file": {
           "file": "src/auth/ulsApiKeyResolver.ts",
           "upload_file": "src/auth/ulsApiKeyResolver.ts",
-          "line": 71,
+          "line": 86,
           "function_name": "resolveApiKey",
           "qualified_function_name": "UlsApiKeyResolver.resolveApiKey",
-          "function_prototype": "resolveApiKey(: ::UlsApiKeyResolver,  : String, ...) : any",
+          "function_prototype": "resolveApiKey(: ::UlsApiKeyResolver,  : String,  : McpProject, ...) : any",
           "scope": "^::UlsApiKeyResolver"
         }
       },
       "flaw_match": {
-        "procedure_hash": "3871525075",
-        "prototype_hash": "3780001097",
+        "procedure_hash": "1911942594",
+        "prototype_hash": "1838136635",
         "flaw_hash": "1571468931",
         "flaw_hash_count": 1,
         "flaw_hash_ordinal": 1,
@@ -592,10 +181,92 @@
         ]
       },
       "flaw_details_link": "https://downloads.veracode.com/securityscan/cwe/v4/java/201.html"
+    },
+    {
+      "title": "fetch",
+      "issue_id": 1001,
+      "image_path": "src/auth/tokenExchanger.ts",
+      "gob": "B",
+      "severity": 2,
+      "issue_type_id": "taint",
+      "issue_type": "Information Exposure Through Sent Data",
+      "cwe_id": "201",
+      "exploit_level": "-1",
+      "display_text": "\u003cspan\u003e The application calls the fetch() function, which will result in data being transferred out of the application (via the network or another medium).  In this case, the message being sent appears to be considered private; this may include credentials such as usernames or passwords, data normally stored in cryptographically-protected vaults such as keychains, or other private information.  \u003c/span\u003e \u003cspan\u003eEnsure that the transfer of the sensitive data is intended and that it does not violate application security policy.  This flaw is categorized as low severity because it only impacts confidentiality, not integrity or availability.  However, in the context of a mobile application, the significance of an information leak may be much greater, especially if misaligned with user expectations or data privacy policies.\u003c/span\u003e \u003cspan\u003eReferences: \u003ca href\u003d\"https://cwe.mitre.org/data/definitions/201.html\"\u003eCWE\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/Top10/A05_2021-Security_Misconfiguration/\"\u003eOWASP Security Misconfiguration\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/Top10/A02_2021-Cryptographic_Failures/\"\u003eOWASP Cryptographic Failures\u003c/a\u003e\u003c/span\u003e",
+      "files": {
+        "source_file": {
+          "file": "src/auth/tokenExchanger.ts",
+          "upload_file": "src/auth/tokenExchanger.ts",
+          "line": 80,
+          "function_name": "exchangeToken",
+          "qualified_function_name": "TokenExchanger.exchangeToken",
+          "function_prototype": "exchangeToken(: ::TokenExchanger,  : String, ...) : any",
+          "scope": "^::TokenExchanger"
+        }
+      },
+      "flaw_match": {
+        "procedure_hash": "3594801488",
+        "prototype_hash": "541915429",
+        "flaw_hash": "1571468931",
+        "flaw_hash_count": 1,
+        "flaw_hash_ordinal": 1,
+        "cause_hash": "2755370418",
+        "cause_hash_count": 1,
+        "cause_hash_ordinal": 1,
+        "cause_hash2": "438364638",
+        "cause_hash2_ordinal": "1"
+      },
+      "stack_dumps": {
+        "stack_dump": [
+          {}
+        ]
+      },
+      "flaw_details_link": "https://downloads.veracode.com/securityscan/cwe/v4/java/201.html"
+    },
+    {
+      "title": "fetch",
+      "issue_id": 1000,
+      "image_path": "src/auth/mcpProjectResolver.ts",
+      "gob": "B",
+      "severity": 2,
+      "issue_type_id": "taint",
+      "issue_type": "Information Exposure Through Sent Data",
+      "cwe_id": "201",
+      "exploit_level": "-1",
+      "display_text": "\u003cspan\u003e The application calls the fetch() function, which will result in data being transferred out of the application (via the network or another medium).  In this case, the message being sent appears to be considered private; this may include credentials such as usernames or passwords, data normally stored in cryptographically-protected vaults such as keychains, or other private information.  \u003c/span\u003e \u003cspan\u003eEnsure that the transfer of the sensitive data is intended and that it does not violate application security policy.  This flaw is categorized as low severity because it only impacts confidentiality, not integrity or availability.  However, in the context of a mobile application, the significance of an information leak may be much greater, especially if misaligned with user expectations or data privacy policies.\u003c/span\u003e \u003cspan\u003eReferences: \u003ca href\u003d\"https://cwe.mitre.org/data/definitions/201.html\"\u003eCWE\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/Top10/A05_2021-Security_Misconfiguration/\"\u003eOWASP Security Misconfiguration\u003c/a\u003e \u003ca href\u003d\"https://owasp.org/Top10/A02_2021-Cryptographic_Failures/\"\u003eOWASP Cryptographic Failures\u003c/a\u003e\u003c/span\u003e",
+      "files": {
+        "source_file": {
+          "file": "src/auth/mcpProjectResolver.ts",
+          "upload_file": "src/auth/mcpProjectResolver.ts",
+          "line": 138,
+          "function_name": "connectRequest",
+          "qualified_function_name": "McpProjectResolver.connectRequest",
+          "function_prototype": "connectRequest(: ::McpProjectResolver,  : String,  : String,  : Record, ...) : any",
+          "scope": "^::McpProjectResolver"
+        }
+      },
+      "flaw_match": {
+        "procedure_hash": "3985807880",
+        "prototype_hash": "2171171610",
+        "flaw_hash": "55982450",
+        "flaw_hash_count": 1,
+        "flaw_hash_ordinal": 1,
+        "cause_hash": "1607772930",
+        "cause_hash_count": 1,
+        "cause_hash_ordinal": 1,
+        "cause_hash2": "1522093433",
+        "cause_hash2_ordinal": "6"
+      },
+      "stack_dumps": {
+        "stack_dump": [
+          {}
+        ]
+      },
+      "flaw_details_link": "https://downloads.veracode.com/securityscan/cwe/v4/java/201.html"
     }
   ],
   "selected_modules": [],
-  "engine_version": "20260622142855",
-  "pipeline_scan": "26.3.0-0",
+  "engine_version": "20260806120029",
+  "pipeline_scan": "26.7.0-0",
   "dev_stage": "DEVELOPMENT"
 }


### PR DESCRIPTION
**Why?**

Right now all people who click SSO login are not getting billed, because by default they get temporary freemium key.

This PR creates a new functionality for ENTERPRISE customers for automatic selection of their project's bundle with MCP Server as a product inside.

**Here is the process:**

- check whether users token contains workforce tenant(tid) if yes, we initiate process - if no, it means user is regular customer or token is invalid(both fallback cases were already supported before)

- on behalf of user, we use their bearerToken to request from ULS token with ACCOUNT_MANAGEMENT scope, which allows to call Project Management API

- When the account management scope token is received - we request from Project management API to ListProjects() and then one by one we check with GetProject() with_products:true flag where the MCPServer product code is. If we encounter MCPServer - we return project_id and bundle_id of those where MCP was found. If no projects, bundles, MCPServer was not found anywhere in users account - we throw.

- When we get the project_id and bundle_id - we use those in ULS /token request with scope containing both params, to get an API key for that specific project and bundle scope.

That is the whole process in changes.

**Other change:** 
- multiple test to assert functionality is correct

**How was functionality tested?**
I used real SSO bearerToken from my account and called locally running MCP server through whole flow. Will be tested in dev as well.