### PR TITLE
chore(deps): maps-sdk 0.51.3 + maplibre-gl 6, with MapLibre's worker inlined into the apps

### DIFF
--- a/.github/workflows/quality_checks.yml
+++ b/.github/workflows/quality_checks.yml
@@ -48,6 +48,15 @@ jobs:
       - name: Build
         run: pnpm build
 
+      # Only the map-worker spec: it is the one e2e test that needs no API key,
+      # and it covers a regression the steps above cannot see — a MapLibre or
+      # app-bundling change that leaves the map rendering blank.
+      - name: Install Chromium for Playwright
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: E2E — MCP App map rendering
+        run: pnpm exec playwright test e2e/mapWorker.spec.ts
+
       - name: Unit tests + integration tests (Genesis)
         run: pnpm test:all
         env:

--- a/e2e/fixtures/map-worker-app/app.html
+++ b/e2e/fixtures/map-worker-app/app.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>MapLibre worker probe</title>
+    <style>
+      html, body { margin: 0; }
+      #map { width: 640px; height: 480px; }
+    </style>
+  </head>
+  <body>
+    <div id="map"></div>
+    <script type="module" src="./app.ts"></script>
+  </body>
+</html>

--- a/e2e/fixtures/map-worker-app/app.ts
+++ b/e2e/fixtures/map-worker-app/app.ts
@@ -1,0 +1,65 @@
+/**
+ * Fixture app for the MapLibre worker e2e test.
+ *
+ * It imports maplibre-gl the same way the real MCP Apps do and is built through
+ * the same single-file Vite config, so it stands in for any of them. The style
+ * is inline and the data is local: the probe must not need an API key or any
+ * network access, only the worker.
+ */
+import { Map as MapLibreMap } from "maplibre-gl";
+import type { MapWorkerProbe, ProbeWindow } from "./probe";
+
+const SOURCE_ID = "probe-points";
+const LAYER_ID = "probe-circles";
+
+const errors: string[] = [];
+
+const map = new MapLibreMap({
+  container: "map",
+  style: { version: 8, sources: {}, layers: [] },
+  center: [0, 0],
+  zoom: 4,
+  attributionControl: false,
+});
+
+const probe: MapWorkerProbe = {
+  mapLoaded: false,
+  sourceLoaded: () => Boolean(map.getSource(SOURCE_ID)) && map.isSourceLoaded(SOURCE_ID),
+  renderedFeatures: () =>
+    map.getLayer(LAYER_ID) ? map.queryRenderedFeatures({ layers: [LAYER_ID] }).length : 0,
+  errors,
+};
+(window as ProbeWindow).mapWorkerProbe = probe;
+
+map.on("error", (event: unknown) => {
+  const err = (event as { error?: Error })?.error;
+  errors.push(err?.message ?? String(event));
+});
+
+map.on("load", () => {
+  // A GeoJSON source is the cheapest way to make the worker do real work:
+  // MapLibre hands the data to the worker to cut into tiles, so if the worker
+  // never starts, the source stays unloaded and no feature is ever rendered.
+  map.addSource(SOURCE_ID, {
+    type: "geojson",
+    data: {
+      type: "FeatureCollection",
+      features: [
+        [0, 0],
+        [0.2, 0.2],
+        [-0.2, -0.2],
+      ].map(([lng, lat]) => ({
+        type: "Feature" as const,
+        properties: {},
+        geometry: { type: "Point" as const, coordinates: [lng, lat] },
+      })),
+    },
+  });
+  map.addLayer({
+    id: LAYER_ID,
+    type: "circle",
+    source: SOURCE_ID,
+    paint: { "circle-radius": 20 },
+  });
+  probe.mapLoaded = true;
+});

--- a/e2e/fixtures/map-worker-app/app.ts
+++ b/e2e/fixtures/map-worker-app/app.ts
@@ -7,12 +7,15 @@
  * network access, only the worker.
  */
 import { Map as MapLibreMap } from "maplibre-gl";
+import { useInlinedMaplibreWorker } from "@shared/maplibre-worker";
 import type { MapWorkerProbe, ProbeWindow } from "./probe";
 
 const SOURCE_ID = "probe-points";
 const LAYER_ID = "probe-circles";
 
 const errors: string[] = [];
+
+useInlinedMaplibreWorker();
 
 const map = new MapLibreMap({
   container: "map",

--- a/e2e/fixtures/map-worker-app/probe.ts
+++ b/e2e/fixtures/map-worker-app/probe.ts
@@ -1,0 +1,20 @@
+/**
+ * Shape the fixture app exposes on `window` for the worker e2e test to read.
+ * Types only — the spec imports this from Node, so it must never pull in
+ * maplibre-gl or any other browser code.
+ */
+export interface MapWorkerProbe {
+  /** Set once the map has fired its `load` event and the probe layer is added. */
+  mapLoaded: boolean;
+  /** Whether MapLibre considers the probe's GeoJSON source fully loaded. */
+  sourceLoaded: () => boolean;
+  /** Features MapLibre actually rendered — zero means the worker never parsed. */
+  renderedFeatures: () => number;
+  /** Errors emitted by the map. */
+  errors: string[];
+}
+
+/** Key the fixture app assigns the probe to. */
+export const PROBE_KEY = "mapWorkerProbe";
+
+export type ProbeWindow = Window & { [PROBE_KEY]?: MapWorkerProbe };

--- a/e2e/mapWorker.spec.ts
+++ b/e2e/mapWorker.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * Guards the one failure mode that the build, the type-checker and the unit
+ * tests all miss: MapLibre's web worker not starting inside a single-file app.
+ *
+ * Each MCP App ships as one inlined HTML file served as a `ui://` resource, so
+ * nothing can be fetched from next to it. A MapLibre build that loads its
+ * worker from a sibling URL still fires `load` — the style is parsed on the
+ * main thread — but every source stays unloaded, so the map renders blank while
+ * looking healthy. This test fails loudly on that instead.
+ */
+import { test, expect } from "@playwright/test";
+import http from "http";
+import type { AddressInfo } from "net";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { fileURLToPath } from "url";
+import { build } from "vite";
+import { appViteConfig } from "../scripts/appViteConfig";
+import type { ProbeWindow } from "./fixtures/map-worker-app/probe";
+
+// SwiftShader gives headless Chromium the WebGL2 context MapLibre 6 requires.
+test.use({ launchOptions: { args: ["--use-gl=angle", "--enable-unsafe-swiftshader"] } });
+
+const APP_DIR = fileURLToPath(new URL("fixtures/map-worker-app", import.meta.url));
+
+let server: http.Server;
+let outDir: string;
+let appUrl: string;
+
+test.beforeAll(async () => {
+  outDir = fs.mkdtempSync(path.join(os.tmpdir(), "tomtom-mcp-map-worker-"));
+  await build(
+    appViteConfig({
+      appDir: APP_DIR,
+      htmlPath: path.join(APP_DIR, "app.html"),
+      outDir,
+      logLevel: "silent",
+    })
+  );
+
+  // Serve only what the bundle produced. A request for anything else 404s, the
+  // same as an MCP host that can hand over a single HTML resource and nothing
+  // more.
+  server = http.createServer((req, res) => {
+    const name = path.basename((req.url ?? "/").split("?")[0]) || "app.html";
+    const file = path.join(outDir, name);
+    if (!file.startsWith(outDir) || !fs.existsSync(file)) {
+      res.writeHead(404).end("not found");
+      return;
+    }
+    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+    res.end(fs.readFileSync(file));
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  appUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}/app.html`;
+});
+
+test.afterAll(async () => {
+  await new Promise<void>((resolve) => server?.close(() => resolve()));
+  fs.rmSync(outDir, { recursive: true, force: true });
+});
+
+test.describe("MCP App map rendering", () => {
+  test("MapLibre's worker parses source data inside the single-file bundle", async ({ page }) => {
+    const workerFetchFailures: string[] = [];
+    const workerConsoleErrors: string[] = [];
+
+    const isWorkerAsset = (url: string) => /worker/i.test(url);
+    page.on("requestfailed", (req) => {
+      if (isWorkerAsset(req.url())) {
+        workerFetchFailures.push(`${req.url()} (${req.failure()?.errorText ?? "failed"})`);
+      }
+    });
+    page.on("response", (res) => {
+      if (res.status() >= 400 && isWorkerAsset(res.url())) {
+        workerFetchFailures.push(`${res.url()} (HTTP ${res.status()})`);
+      }
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error" && /worker/i.test(msg.text())) {
+        workerConsoleErrors.push(msg.text());
+      }
+    });
+
+    await page.goto(appUrl);
+
+    await expect
+      .poll(() => page.evaluate(() => (window as ProbeWindow).mapWorkerProbe?.mapLoaded === true), {
+        timeout: 30_000,
+        message: "the map never reached its load event",
+      })
+      .toBe(true);
+
+    // The real assertion: data went to the worker and came back as geometry.
+    await expect
+      .poll(() => page.evaluate(() => (window as ProbeWindow).mapWorkerProbe?.renderedFeatures() ?? -1), {
+        timeout: 30_000,
+        message:
+          "MapLibre rendered no features, so its worker never parsed the source. " +
+          "A single-file app cannot fetch a worker from a sibling URL — the worker " +
+          "has to be inlined into the bundle.",
+      })
+      .toBeGreaterThan(0);
+
+    expect(await page.evaluate(() => (window as ProbeWindow).mapWorkerProbe?.sourceLoaded())).toBe(true);
+
+    // Diagnostics that name the cause when the assertion above fails.
+    expect(workerFetchFailures, "MapLibre tried to fetch a worker that the bundle does not ship").toEqual([]);
+    expect(workerConsoleErrors, "MapLibre could not construct its worker").toEqual([]);
+    expect(await page.evaluate(() => (window as ProbeWindow).mapWorkerProbe?.errors)).toEqual([]);
+  });
+});

--- a/e2e/mapWorker.spec.ts
+++ b/e2e/mapWorker.spec.ts
@@ -8,7 +8,7 @@
  * main thread — but every source stays unloaded, so the map renders blank while
  * looking healthy. This test fails loudly on that instead.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import http from "http";
 import type { AddressInfo } from "net";
 import fs from "fs";
@@ -24,8 +24,15 @@ test.use({ launchOptions: { args: ["--use-gl=angle", "--enable-unsafe-swiftshade
 
 const APP_DIR = fileURLToPath(new URL("fixtures/map-worker-app", import.meta.url));
 
-let server: http.Server;
-let outDir: string;
+const CONTENT_TYPES: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+};
+
+let server: http.Server | undefined;
+let outDir: string | undefined;
 let appUrl: string;
 
 test.beforeAll(async () => {
@@ -39,27 +46,53 @@ test.beforeAll(async () => {
     })
   );
 
-  // Serve only what the bundle produced. A request for anything else 404s, the
-  // same as an MCP host that can hand over a single HTML resource and nothing
-  // more.
+  // Serve only what the bundle produced, with the real content type for each
+  // extension: a sibling worker chunk served as text/html would be rejected by
+  // Chromium for the wrong reason and mask what actually regressed.
+  const root = outDir;
   server = http.createServer((req, res) => {
     const name = path.basename((req.url ?? "/").split("?")[0]) || "app.html";
-    const file = path.join(outDir, name);
-    if (!file.startsWith(outDir) || !fs.existsSync(file)) {
+    const file = path.join(root, name);
+    if (!fs.existsSync(file)) {
       res.writeHead(404).end("not found");
       return;
     }
-    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+    res.writeHead(200, {
+      "Content-Type": CONTENT_TYPES[path.extname(file)] ?? "application/octet-stream",
+    });
     res.end(fs.readFileSync(file));
   });
-  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  await new Promise<void>((resolve) => server?.listen(0, "127.0.0.1", resolve));
   appUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}/app.html`;
 });
 
 test.afterAll(async () => {
-  await new Promise<void>((resolve) => server?.close(() => resolve()));
-  fs.rmSync(outDir, { recursive: true, force: true });
+  // Guarded: when the build above throws, `server` is never assigned, and an
+  // unconditional `server?.close(cb)` would leave this promise pending until
+  // Playwright's hook timeout — hiding the build error that actually failed.
+  if (server) {
+    await new Promise<void>((resolve) => server?.close(() => resolve()));
+  }
+  if (outDir) {
+    fs.rmSync(outDir, { recursive: true, force: true });
+  }
 });
+
+/** Read a probe value until `done` accepts it or the deadline passes. Never throws. */
+async function pollProbe<T>(
+  page: Page,
+  read: () => Promise<T>,
+  done: (value: T) => boolean,
+  timeoutMs: number
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let value = await read();
+  while (!done(value) && Date.now() < deadline) {
+    await page.waitForTimeout(250);
+    value = await read();
+  }
+  return value;
+}
 
 test.describe("MCP App map rendering", () => {
   test("MapLibre's worker parses source data inside the single-file bundle", async ({ page }) => {
@@ -83,31 +116,55 @@ test.describe("MCP App map rendering", () => {
       }
     });
 
+    // The invariant the worker behaviour hangs off: one self-contained file, so
+    // there is nothing beside it that MapLibre could load a worker from.
+    expect(
+      fs.readdirSync(outDir as string),
+      "an MCP App must build to exactly one self-contained file"
+    ).toEqual(["app.html"]);
+
     await page.goto(appUrl);
 
-    await expect
-      .poll(() => page.evaluate(() => (window as ProbeWindow).mapWorkerProbe?.mapLoaded === true), {
-        timeout: 30_000,
-        message: "the map never reached its load event",
-      })
+    // Polled without throwing, so every diagnostic below still runs and gets
+    // reported when the map comes up blank.
+    const mapLoaded = await pollProbe(
+      page,
+      () => page.evaluate(() => (window as ProbeWindow).mapWorkerProbe?.mapLoaded === true),
+      (loaded) => loaded,
+      30_000
+    );
+    const rendered = await pollProbe(
+      page,
+      () => page.evaluate(() => (window as ProbeWindow).mapWorkerProbe?.renderedFeatures() ?? -1),
+      (count) => count > 0,
+      30_000
+    );
+
+    // Soft, so a blank map reports the cause alongside the symptom instead of
+    // stopping at whichever assertion happens to come first.
+    expect
+      .soft(workerFetchFailures, "MapLibre tried to fetch a worker the bundle does not ship")
+      .toEqual([]);
+    expect.soft(workerConsoleErrors, "MapLibre could not construct its worker").toEqual([]);
+    expect
+      .soft(
+        await page.evaluate(() => (window as ProbeWindow).mapWorkerProbe?.errors),
+        "the map reported errors"
+      )
+      .toEqual([]);
+    expect.soft(mapLoaded, "the map never reached its load event").toBe(true);
+    expect
+      .soft(
+        await page.evaluate(() => (window as ProbeWindow).mapWorkerProbe?.sourceLoaded()),
+        "MapLibre never finished loading the probe source"
+      )
       .toBe(true);
 
-    // The real assertion: data went to the worker and came back as geometry.
-    await expect
-      .poll(() => page.evaluate(() => (window as ProbeWindow).mapWorkerProbe?.renderedFeatures() ?? -1), {
-        timeout: 30_000,
-        message:
-          "MapLibre rendered no features, so its worker never parsed the source. " +
-          "A single-file app cannot fetch a worker from a sibling URL — the worker " +
-          "has to be inlined into the bundle.",
-      })
-      .toBeGreaterThan(0);
-
-    expect(await page.evaluate(() => (window as ProbeWindow).mapWorkerProbe?.sourceLoaded())).toBe(true);
-
-    // Diagnostics that name the cause when the assertion above fails.
-    expect(workerFetchFailures, "MapLibre tried to fetch a worker that the bundle does not ship").toEqual([]);
-    expect(workerConsoleErrors, "MapLibre could not construct its worker").toEqual([]);
-    expect(await page.evaluate(() => (window as ProbeWindow).mapWorkerProbe?.errors)).toEqual([]);
+    expect(
+      rendered,
+      "MapLibre rendered no features, so its worker never parsed the source. " +
+        "A single-file app cannot fetch a worker from a sibling URL — the worker " +
+        "has to be inlined into the bundle."
+    ).toBeGreaterThan(0);
   });
 });

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@modelcontextprotocol/ext-apps": "^1.7.5",
     "@modelcontextprotocol/sdk": "^1.30.0",
-    "@tomtom-org/maps-sdk": "^0.51.2",
+    "@tomtom-org/maps-sdk": "^0.51.3",
     "@turf/buffer": "^7.4.0",
     "@types/geojson": "^7946.0.16",
     "axios": "^1.19.0",
@@ -90,7 +90,7 @@
     "archiver": "^8.0.0",
     "concurrently": "^10.0.5",
     "cross-env": "^10.1.0",
-    "maplibre-gl": "^5.24.0",
+    "maplibre-gl": "^6.4.0",
     "rolldown": "^1.2.4",
     "skills": "^1.5.22",
     "tsx": "^4.23.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ importers:
         specifier: ^1.30.0
         version: 1.30.0(supports-color@10.2.2)(zod@4.4.3)
       '@tomtom-org/maps-sdk':
-        specifier: ^0.51.2
-        version: 0.51.2(@turf/turf@7.3.5)(lodash-es@4.18.1)(maplibre-gl@5.24.0)(zod@4.4.3)
+        specifier: ^0.51.3
+        version: 0.51.3(@turf/turf@7.3.5)(lodash-es@4.18.1)(maplibre-gl@6.4.0)(zod@4.4.3)
       '@turf/buffer':
         specifier: ^7.4.0
         version: 7.4.0
@@ -114,8 +114,8 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0
       maplibre-gl:
-        specifier: ^5.24.0
-        version: 5.24.0
+        specifier: ^6.4.0
+        version: 6.4.0
       rolldown:
         specifier: ^1.2.4
         version: 1.2.4
@@ -535,24 +535,17 @@ packages:
   '@mapbox/tiny-sdf@2.2.0':
     resolution: {integrity: sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==}
 
-  '@mapbox/unitbezier@0.0.1':
-    resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
-
   '@mapbox/unitbezier@1.0.0':
     resolution: {integrity: sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==}
 
-  '@mapbox/vector-tile@2.0.5':
-    resolution: {integrity: sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw==}
-
-  '@mapbox/whoots-js@3.1.0':
-    resolution: {integrity: sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==}
-    engines: {node: '>=6.0.0'}
+  '@mapbox/vector-tile@3.0.0':
+    resolution: {integrity: sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==}
 
   '@maplibre/geojson-vt@6.1.1':
     resolution: {integrity: sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==}
 
-  '@maplibre/maplibre-gl-style-spec@24.10.0':
-    resolution: {integrity: sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw==}
+  '@maplibre/maplibre-gl-style-spec@26.2.1':
+    resolution: {integrity: sha512-QFKCXkOeSzOr8jF75jm6kySOg+dUvOehPhRi68gcOYPHb7U5JloUq0dJW0Y5/fZV8ygfT0Vp2RWodvq+fyxFWA==}
     hasBin: true
 
   '@maplibre/mlt@1.1.12':
@@ -960,13 +953,13 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@tomtom-org/maps-sdk@0.51.2':
-    resolution: {integrity: sha512-ryO1kWue7mXGLHYrGR6iMd/ISn3SKhrQb1xXd2G/ITErkY7GgWcRUiRno7r/HFUOK64zIGEflW+G79ZrTi2E7Q==}
+  '@tomtom-org/maps-sdk@0.51.3':
+    resolution: {integrity: sha512-cNk2YfqznI9Iav40z4CZ9cfKKIGWxnRTp90WPRmYhLLKjfW4hMaoELR6DrbD4ZS/kSeTYgWMhN2LW7UGWhzqDQ==}
     engines: {node: '>=24', pnpm: '>=11'}
     peerDependencies:
       '@turf/turf': ^7.3.5
       lodash-es: ^4.18.1
-      maplibre-gl: ^5.24.0
+      maplibre-gl: ^6.4.0
       zod: ^4.4.3
 
   '@turf/along@7.3.5':
@@ -2406,8 +2399,8 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
-  maplibre-gl@5.24.0:
-    resolution: {integrity: sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==}
+  maplibre-gl@6.4.0:
+    resolution: {integrity: sha512-pCgDUsaYFuZwIH37aV2qF4m03nZPlW79DlqC+cQ+48tpqiqW2SJyA7fEOcFrS5ilDK493f0X3LxiH17T5BqV7g==}
     engines: {node: '>=16.14.0', npm: '>=8.1.0'}
 
   math-intrinsics@1.1.0:
@@ -2582,10 +2575,6 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pbf@4.0.2:
-    resolution: {integrity: sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==}
-    hasBin: true
 
   pbf@5.1.2:
     resolution: {integrity: sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==}
@@ -3587,23 +3576,19 @@ snapshots:
 
   '@mapbox/tiny-sdf@2.2.0': {}
 
-  '@mapbox/unitbezier@0.0.1': {}
-
   '@mapbox/unitbezier@1.0.0': {}
 
-  '@mapbox/vector-tile@2.0.5':
+  '@mapbox/vector-tile@3.0.0':
     dependencies:
       '@mapbox/point-geometry': 1.1.0
       '@types/geojson': 7946.0.16
-      pbf: 4.0.2
-
-  '@mapbox/whoots-js@3.1.0': {}
+      pbf: 5.1.2
 
   '@maplibre/geojson-vt@6.1.1':
     dependencies:
       kdbush: 4.1.0
 
-  '@maplibre/maplibre-gl-style-spec@24.10.0':
+  '@maplibre/maplibre-gl-style-spec@26.2.1':
     dependencies:
       '@mapbox/jsonlint-lines-primitives': 2.0.3
       '@mapbox/unitbezier': 1.0.0
@@ -3929,11 +3914,11 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@tomtom-org/maps-sdk@0.51.2(@turf/turf@7.3.5)(lodash-es@4.18.1)(maplibre-gl@5.24.0)(zod@4.4.3)':
+  '@tomtom-org/maps-sdk@0.51.3(@turf/turf@7.3.5)(lodash-es@4.18.1)(maplibre-gl@6.4.0)(zod@4.4.3)':
     dependencies:
       '@turf/turf': 7.3.5
       lodash-es: 4.18.1
-      maplibre-gl: 5.24.0
+      maplibre-gl: 6.4.0
       zod: 4.4.3
 
   '@turf/along@7.3.5':
@@ -6209,16 +6194,14 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
-  maplibre-gl@5.24.0:
+  maplibre-gl@6.4.0:
     dependencies:
-      '@mapbox/jsonlint-lines-primitives': 2.0.3
       '@mapbox/point-geometry': 1.1.0
       '@mapbox/tiny-sdf': 2.2.0
-      '@mapbox/unitbezier': 0.0.1
-      '@mapbox/vector-tile': 2.0.5
-      '@mapbox/whoots-js': 3.1.0
+      '@mapbox/unitbezier': 1.0.0
+      '@mapbox/vector-tile': 3.0.0
       '@maplibre/geojson-vt': 6.1.1
-      '@maplibre/maplibre-gl-style-spec': 24.10.0
+      '@maplibre/maplibre-gl-style-spec': 26.2.1
       '@maplibre/mlt': 1.1.12
       '@maplibre/vt-pbf': 4.3.2
       '@types/geojson': 7946.0.16
@@ -6226,7 +6209,7 @@ snapshots:
       gl-matrix: 3.4.4
       kdbush: 4.1.0
       murmurhash-js: 1.0.0
-      pbf: 4.0.2
+      pbf: 5.1.2
       potpack: 2.1.0
       quickselect: 3.0.0
       tinyqueue: 3.0.0
@@ -6350,10 +6333,6 @@ snapshots:
   path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
-
-  pbf@4.0.2:
-    dependencies:
-      resolve-protobuf-schema: 2.1.0
 
   pbf@5.1.2:
     dependencies:

--- a/scripts/appViteConfig.ts
+++ b/scripts/appViteConfig.ts
@@ -1,0 +1,45 @@
+/**
+ * Vite options shared by every MCP App build.
+ *
+ * The apps ship as a single inlined HTML file (one `ui://` resource each), so
+ * this config is what decides that no sibling assets are emitted. The e2e
+ * worker test builds through it too, so a change here cannot silently diverge
+ * from what that test exercises.
+ */
+import path from 'path';
+import { fileURLToPath } from 'url';
+import type { InlineConfig } from 'vite';
+import { viteSingleFile } from 'vite-plugin-singlefile';
+
+const ROOT_DIR = fileURLToPath(new URL('..', import.meta.url));
+export const APPS_DIR = path.join(ROOT_DIR, 'src/apps');
+
+export interface AppBuildTarget {
+  /** Directory Vite treats as the app root. */
+  appDir: string;
+  /** Entry HTML file. */
+  htmlPath: string;
+  /** Where the single-file bundle is written. */
+  outDir: string;
+  logLevel?: InlineConfig['logLevel'];
+}
+
+export function appViteConfig({
+  appDir,
+  htmlPath,
+  outDir,
+  logLevel = 'error',
+}: AppBuildTarget): InlineConfig {
+  return {
+    root: appDir,
+    logLevel,
+    resolve: { alias: { '@shared': path.join(APPS_DIR, 'shared') } },
+    plugins: [viteSingleFile()],
+    build: {
+      outDir,
+      emptyOutDir: true,
+      rolldownOptions: { input: htmlPath },
+      minify: 'oxc',
+    },
+  };
+}

--- a/scripts/appViteConfig.ts
+++ b/scripts/appViteConfig.ts
@@ -6,13 +6,58 @@
  * worker test builds through it too, so a change here cannot silently diverge
  * from what that test exercises.
  */
+import { createRequire } from 'module';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import type { InlineConfig } from 'vite';
+import { build } from 'rolldown';
+import type { InlineConfig, Plugin } from 'vite';
 import { viteSingleFile } from 'vite-plugin-singlefile';
 
 const ROOT_DIR = fileURLToPath(new URL('..', import.meta.url));
 export const APPS_DIR = path.join(ROOT_DIR, 'src/apps');
+
+/** Module whose contents are replaced with the bundled MapLibre worker. */
+const WORKER_SOURCE_MODULE = path.join(APPS_DIR, 'shared/maplibre-worker-source.ts');
+
+const require = createRequire(import.meta.url);
+
+let workerSource: Promise<string> | undefined;
+
+/**
+ * Bundles MapLibre's worker chunk and the shared chunk it imports into one
+ * self-contained module, so it can run from a blob with nothing to fetch.
+ * Bundled once and reused across every app build.
+ */
+function bundleMaplibreWorker(): Promise<string> {
+  workerSource ??= build({
+    input: require.resolve('maplibre-gl/dist/maplibre-gl-worker.mjs'),
+    platform: 'browser',
+    write: false,
+    output: { format: 'es', minify: true },
+  }).then(({ output }) =>
+    output
+      .filter((chunk) => chunk.type === 'chunk')
+      .map((chunk) => chunk.code)
+      .join('\n'),
+  );
+  return workerSource;
+}
+
+/**
+ * Hands the bundled worker source to `maplibre-worker-source.ts`, which
+ * `useInlinedMaplibreWorker()` turns into the blob MapLibre loads its worker
+ * from. Nothing is emitted next to the app, so the bundle stays a single file.
+ */
+function inlineMaplibreWorker(): Plugin {
+  return {
+    name: 'inline-maplibre-worker',
+    async load(id) {
+      const [filePath] = id.split('?');
+      if (path.resolve(filePath) !== WORKER_SOURCE_MODULE) return null;
+      return `export default ${JSON.stringify(await bundleMaplibreWorker())};`;
+    },
+  };
+}
 
 export interface AppBuildTarget {
   /** Directory Vite treats as the app root. */
@@ -34,7 +79,7 @@ export function appViteConfig({
     root: appDir,
     logLevel,
     resolve: { alias: { '@shared': path.join(APPS_DIR, 'shared') } },
-    plugins: [viteSingleFile()],
+    plugins: [inlineMaplibreWorker(), viteSingleFile()],
     build: {
       outDir,
       emptyOutDir: true,

--- a/scripts/build-apps.ts
+++ b/scripts/build-apps.ts
@@ -7,11 +7,12 @@ import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
 import { build } from 'vite';
-import { appViteConfig } from './appViteConfig';
+import { APPS_DIR, appViteConfig } from './appViteConfig';
 
 const ALL_CATEGORIES = ['search', 'routing', 'traffic', 'map', 'data-viz'];
+// APPS_DIR comes from appViteConfig so app discovery and the `@shared` alias
+// cannot drift apart if src/apps ever moves.
 const ROOT_DIR = fileURLToPath(new URL('..', import.meta.url));
-const APPS_DIR = path.join(ROOT_DIR, 'src/apps');
 const DIST_DIR = path.join(ROOT_DIR, 'dist/apps');
 
 const filterCategory = process.env.CATEGORY;

--- a/scripts/build-apps.ts
+++ b/scripts/build-apps.ts
@@ -7,7 +7,7 @@ import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
 import { build } from 'vite';
-import { viteSingleFile } from 'vite-plugin-singlefile';
+import { appViteConfig } from './appViteConfig';
 
 const ALL_CATEGORIES = ['search', 'routing', 'traffic', 'map', 'data-viz'];
 const ROOT_DIR = fileURLToPath(new URL('..', import.meta.url));
@@ -43,18 +43,13 @@ function discoverApps(): AppEntry[] {
 
 async function buildApp(app: AppEntry): Promise<{ app: AppEntry; success: boolean; error?: string }> {
   try {
-    await build({
-      root: app.appDir,
-      logLevel: 'error',
-      resolve: { alias: { '@shared': path.join(APPS_DIR, 'shared') } },
-      plugins: [viteSingleFile()],
-      build: {
+    await build(
+      appViteConfig({
+        appDir: app.appDir,
+        htmlPath: app.htmlPath,
         outDir: path.join(DIST_DIR, app.id),
-        emptyOutDir: true,
-        rolldownOptions: { input: app.htmlPath },
-        minify: 'oxc',
-      },
-    });
+      })
+    );
     return { app, success: true };
   } catch (e: unknown) {
     return { app, success: false, error: e instanceof Error ? e.message : String(e) };

--- a/src/apps/shared/maplibre-worker-source.ts
+++ b/src/apps/shared/maplibre-worker-source.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2025 TomTom Navigation B.V.
+ * Licensed under the Apache License, Version 2.0
+ */
+
+/**
+ * Bundled source of MapLibre's worker.
+ *
+ * The app build replaces this module with the real bundle (see
+ * `scripts/appViteConfig.ts`). Everywhere else it stays empty, which leaves
+ * MapLibre's own worker resolution untouched.
+ */
+export default "";

--- a/src/apps/shared/maplibre-worker.ts
+++ b/src/apps/shared/maplibre-worker.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2025 TomTom Navigation B.V.
+ * Licensed under the Apache License, Version 2.0
+ */
+
+import { setWorkerUrl } from "maplibre-gl";
+import workerSource from "./maplibre-worker-source";
+
+let workerUrl: string | undefined;
+
+/**
+ * Points MapLibre at a worker blob built inside the page.
+ *
+ * MapLibre resolves its worker from a URL next to its own module. An MCP App is
+ * a single inlined HTML file, so there is no sibling to fetch: without this the
+ * worker never starts, every source stays unparsed and the map renders blank
+ * while still firing `load`. The app build inlines the worker source so it can
+ * be handed over as a blob instead.
+ *
+ * Call before creating a map — MapLibre reads the URL when it spawns its pool.
+ */
+export function useInlinedMaplibreWorker(): void {
+  if (!workerSource || workerUrl) return;
+  workerUrl = URL.createObjectURL(new Blob([workerSource], { type: "text/javascript" }));
+  setWorkerUrl(workerUrl);
+}

--- a/src/apps/shared/poi-popup.ts
+++ b/src/apps/shared/poi-popup.ts
@@ -87,6 +87,27 @@ export function injectPoiPopupStyles(): void {
 }
 
 /**
+ * Makes the places layers honour the `hidden` feature state, so the marker
+ * under an open popup can be faded out.
+ */
+function applyHidePaint(map: TomTomMap, layerIDs: string[]): void {
+  const expr: PropertyValueSpecification<number> = [
+    "case",
+    ["boolean", ["feature-state", "hidden"], false],
+    0,
+    1,
+  ];
+  for (const layerId of layerIDs) {
+    // Only symbol layers carry icon/text opacity. The places source also has
+    // circle and line layers (cluster badges, connection lines), which render
+    // no individual marker and reject these properties.
+    if (map.mapLibreMap.getLayer(layerId)?.type !== "symbol") continue;
+    map.mapLibreMap.setPaintProperty(layerId, "icon-opacity", expr);
+    map.mapLibreMap.setPaintProperty(layerId, "text-opacity", expr);
+  }
+}
+
+/**
  * Sets up click handlers on PlacesModule to show POI popups
  */
 export function setupPoiPopups(map: TomTomMap, placesModule: PlacesModule): void {
@@ -108,16 +129,7 @@ export function setupPoiPopups(map: TomTomMap, placesModule: PlacesModule): void
     // Apply hide paint expressions once
     if (!hidePaintApplied) {
       hidePaintApplied = true;
-      const expr: PropertyValueSpecification<number> = [
-        "case",
-        ["boolean", ["feature-state", "hidden"], false],
-        0,
-        1,
-      ];
-      for (const layerId of layerIDs) {
-        map.mapLibreMap.setPaintProperty(layerId, "icon-opacity", expr);
-        map.mapLibreMap.setPaintProperty(layerId, "text-opacity", expr);
-      }
+      applyHidePaint(map, layerIDs);
     }
 
     // Hide the clicked marker

--- a/src/apps/shared/sdk-config.ts
+++ b/src/apps/shared/sdk-config.ts
@@ -6,6 +6,7 @@
 import type { App } from "@modelcontextprotocol/ext-apps";
 import { TomTomConfig } from "@tomtom-org/maps-sdk/core";
 import { getAPIKey } from "./api-key";
+import { useInlinedMaplibreWorker } from "./maplibre-worker";
 import { SDK_USER_AGENT_CONFIG_KEY } from "../../utils/userAgent";
 
 /**
@@ -40,7 +41,8 @@ async function fetchMcpAppUserAgent(app: App): Promise<string> {
 }
 
 /**
- * Ensures TomTom SDK config is initialized, fetching API key if necessary
+ * Prepares the SDK for map creation: MapLibre's inlined worker and the TomTom
+ * config, fetching the API key if necessary.
  *
  * @param app - Connected MCP App instance
  */
@@ -48,6 +50,8 @@ export async function ensureTomTomConfigured(app: App): Promise<void> {
   if (configInitialized) {
     return;
   }
+
+  useInlinedMaplibreWorker();
 
   const [apiKey, userAgent] = await Promise.all([getAPIKey(app), fetchMcpAppUserAgent(app)]);
 

--- a/src/tools/helpers/appHtmlCache.test.ts
+++ b/src/tools/helpers/appHtmlCache.test.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2025 TomTom Navigation B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { readAppHtml } from "./appHtmlCache";
+
+// Exercised against a real filesystem: the cache keys off mtime and size, which
+// a mocked fs would only ever report back as whatever the test already decided.
+let tmpDir: string;
+let appCount = 0;
+
+/** A fresh app path, so each test is independent of the module-level cache. */
+function newAppPath(): string {
+  appCount += 1;
+  return path.join(tmpDir, `app-${appCount}.html`);
+}
+
+/** Rewrites a bundle the way a rebuild does, guaranteeing a later mtime. */
+async function rebuild(appPath: string, html: string): Promise<void> {
+  const before = await fs.stat(appPath).catch(() => null);
+  await fs.writeFile(appPath, html);
+  if (before) {
+    const after = await fs.stat(appPath);
+    // Same-millisecond rewrites are possible on a coarse clock; push mtime out
+    // so the test asserts the invalidation rule, not the filesystem's timer.
+    if (after.mtimeMs === before.mtimeMs) {
+      const bumped = new Date(before.mtimeMs + 1000);
+      await fs.utimes(appPath, bumped, bumped);
+    }
+  }
+}
+
+beforeAll(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tomtom-app-html-cache-"));
+});
+
+afterAll(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("readAppHtml", () => {
+  it("should return the bundle's contents", async () => {
+    const appPath = newAppPath();
+    await fs.writeFile(appPath, "<html><body>App</body></html>");
+
+    expect(await readAppHtml(appPath)).toBe("<html><body>App</body></html>");
+  });
+
+  it("should read from disk only once for repeated reads", async () => {
+    const appPath = newAppPath();
+    await fs.writeFile(appPath, "<html><body>App</body></html>");
+    await readAppHtml(appPath);
+
+    const readFile = vi.spyOn(fs, "readFile");
+    expect(await readAppHtml(appPath)).toBe("<html><body>App</body></html>");
+    expect(await readAppHtml(appPath)).toBe("<html><body>App</body></html>");
+
+    expect(readFile).not.toHaveBeenCalled();
+
+    // Control: proves the assertion above is the cache working and not a spy
+    // that was never wired to the call in the first place.
+    await rebuild(appPath, "<html><body>App rebuilt</body></html>");
+    expect(await readAppHtml(appPath)).toBe("<html><body>App rebuilt</body></html>");
+    expect(readFile).toHaveBeenCalledOnce();
+  });
+
+  it("should serve a rebuilt bundle without a restart", async () => {
+    const appPath = newAppPath();
+    await fs.writeFile(appPath, "<html><body>Before</body></html>");
+    expect(await readAppHtml(appPath)).toBe("<html><body>Before</body></html>");
+
+    await rebuild(appPath, "<html><body>After the rebuild</body></html>");
+
+    expect(await readAppHtml(appPath)).toBe("<html><body>After the rebuild</body></html>");
+  });
+
+  it("should invalidate on a same-size rebuild, which only mtime reveals", async () => {
+    const appPath = newAppPath();
+    await fs.writeFile(appPath, "<html><body>aaaa</body></html>");
+    expect(await readAppHtml(appPath)).toBe("<html><body>aaaa</body></html>");
+
+    // Byte-for-byte the same length, so size alone cannot tell these apart.
+    await rebuild(appPath, "<html><body>bbbb</body></html>");
+
+    expect(await readAppHtml(appPath)).toBe("<html><body>bbbb</body></html>");
+  });
+
+  it("should cache each app separately", async () => {
+    const first = newAppPath();
+    const second = newAppPath();
+    await fs.writeFile(first, "<html><body>First</body></html>");
+    await fs.writeFile(second, "<html><body>Second</body></html>");
+
+    expect(await readAppHtml(first)).toBe("<html><body>First</body></html>");
+    expect(await readAppHtml(second)).toBe("<html><body>Second</body></html>");
+    expect(await readAppHtml(first)).toBe("<html><body>First</body></html>");
+  });
+
+  it("should throw when the bundle is missing", async () => {
+    await expect(readAppHtml(newAppPath())).rejects.toThrow();
+  });
+
+  it("should pick up a bundle built after a failed read", async () => {
+    const appPath = newAppPath();
+    // A server started before `build:apps` ran.
+    await expect(readAppHtml(appPath)).rejects.toThrow();
+
+    await fs.writeFile(appPath, "<html><body>Built later</body></html>");
+
+    expect(await readAppHtml(appPath)).toBe("<html><body>Built later</body></html>");
+  });
+});

--- a/src/tools/helpers/appHtmlCache.ts
+++ b/src/tools/helpers/appHtmlCache.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025 TomTom Navigation B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from "node:fs/promises";
+
+interface CachedApp {
+  mtimeMs: number;
+  size: number;
+  html: string;
+}
+
+/** App HTML already read from disk, keyed by absolute file path. */
+const cache = new Map<string, CachedApp>();
+
+/**
+ * Reads an MCP App bundle, serving it from memory once it has been read.
+ *
+ * Each app ships as one inlined HTML file, so a read hands over the whole
+ * bundle: around 2 MB for a map app, which carries MapLibre's inlined worker.
+ * That file only changes when `build:apps` runs, so re-reading and re-decoding
+ * it on every render is pure overhead.
+ *
+ * Validated against mtime and size rather than cached outright, which keeps a
+ * rebuild visible to an already-running server: the `pnpm ui` loop rebuilds the
+ * apps under a server started from `dist`, and a blind cache would serve the
+ * previous bundle until restart. A `stat` costs about a hundredth of what
+ * reading the file costs, so the check is close to free.
+ *
+ * Only successful reads are cached, so a server started before `build:apps` ran
+ * picks the apps up once they exist instead of serving the fallback forever.
+ *
+ * @param htmlPath - Absolute path to the app's `app.html`
+ * @returns The bundle's contents
+ * @throws If the file cannot be stat'd or read
+ */
+export async function readAppHtml(htmlPath: string): Promise<string> {
+  const { mtimeMs, size } = await fs.stat(htmlPath);
+
+  const cached = cache.get(htmlPath);
+  if (cached && cached.mtimeMs === mtimeMs && cached.size === size) {
+    return cached.html;
+  }
+
+  const html = await fs.readFile(htmlPath, "utf-8");
+  cache.set(htmlPath, { mtimeMs, size, html });
+  return html;
+}

--- a/src/tools/helpers/resourceRegistry.test.ts
+++ b/src/tools/helpers/resourceRegistry.test.ts
@@ -18,6 +18,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 const mockReadFile = vi.fn();
+const mockStat = vi.fn();
 
 // Capture the resource handler passed to registerAppResource
 type ResourceResult = {
@@ -39,7 +40,7 @@ const mockRegisterAppResource = vi.fn(
 );
 
 vi.mock("node:fs/promises", () => ({
-  default: { readFile: mockReadFile },
+  default: { readFile: mockReadFile, stat: mockStat },
 }));
 
 vi.mock("@modelcontextprotocol/ext-apps/server", () => ({
@@ -53,13 +54,19 @@ describe("registerAppResourceFromPath", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     capturedResourceHandler = null;
+    // The handler reads through appHtmlCache, which stats before reading.
+    mockStat.mockResolvedValue({ mtimeMs: 1000, size: 42 });
   });
+
+  // appHtmlCache is keyed by file path and outlives a single test, so each test
+  // uses its own app name. Sharing one would let the first test's cached HTML
+  // satisfy the second, which then could not reach the failure path at all.
 
   it("should register a resource and serve HTML content on read", async () => {
     const mockServer = {} as McpServer;
     const resourceUri = "ui://test/app.html";
 
-    await registerAppResourceFromPath(mockServer, resourceUri, "search", "geocode");
+    await registerAppResourceFromPath(mockServer, resourceUri, "search", "serves-html");
 
     expect(mockRegisterAppResource).toHaveBeenCalledOnce();
     expect(capturedResourceHandler).toBeDefined();
@@ -79,7 +86,7 @@ describe("registerAppResourceFromPath", () => {
     const mockServer = {} as McpServer;
     const resourceUri = "ui://test/app.html";
 
-    await registerAppResourceFromPath(mockServer, resourceUri, "search", "geocode");
+    await registerAppResourceFromPath(mockServer, resourceUri, "search", "read-fails");
 
     mockReadFile.mockRejectedValue(new Error("ENOENT"));
     const result = await capturedResourceHandler!();

--- a/src/tools/helpers/resourceRegistry.ts
+++ b/src/tools/helpers/resourceRegistry.ts
@@ -17,10 +17,10 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
 import { registerAppResource, RESOURCE_MIME_TYPE } from "@modelcontextprotocol/ext-apps/server";
-import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { logger } from "../../utils/logger";
+import { readAppHtml } from "./appHtmlCache";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -55,7 +55,7 @@ export async function registerAppResourceFromPath(
     { mimeType: RESOURCE_MIME_TYPE },
     async (): Promise<ReadResourceResult> => {
       try {
-        const html = await fs.readFile(htmlPath, "utf-8");
+        const html = await readAppHtml(htmlPath);
 
         return {
           contents: [


### PR DESCRIPTION
## What

Moves to `@tomtom-org/maps-sdk@0.51.3`, which peer-requires `maplibre-gl@^6.4.0`, and makes the MCP Apps work on MapLibre 6.

Inlining the worker makes each map bundle ~460k bigger, so it also stops re-reading those bundles from disk on every resource read — see [Resource reads](#resource-reads).

MapLibre 6 resolves its worker from a URL next to its own module:

```js
const workerName = moduleUrl.endsWith("-dev.mjs") ? "maplibre-gl-worker-dev.mjs" : "maplibre-gl-worker.mjs";
return new URL(`./${workerName}`, moduleUrl).href;
```

Each MCP App ships as **one inlined HTML file** served as a `ui://` resource, so there is no sibling to fetch. Without a worker the map still fires `load` — style parsing is main-thread work — but every source stays unparsed, so it renders blank while looking healthy.

## Inlining the worker

- `scripts/appViteConfig.ts` bundles `maplibre-gl-worker.mjs` together with the 482 KB shared chunk it imports into one self-contained module (rolldown, once per build) and substitutes it for `src/apps/shared/maplibre-worker-source.ts`.
- `useInlinedMaplibreWorker()` turns that source into a blob URL and hands it to MapLibre's `setWorkerUrl()`. It runs from `ensureTomTomConfigured()`, which all 15 map apps await before creating a map.
- The source module is empty anywhere else, so the call is a no-op for unit tests and the server build.
- Nothing is emitted next to the app: each bundle is still exactly one `app.html`.

A blob-URL worker is not a new mechanism here — it is what MapLibre 5 already did. 5.24 shipped UMD only (`main: dist/maplibre-gl.js`, no `.mjs`), so that is the build Vite bundled, and its rollup prelude self-inlined the worker:

```js
maplibregl.setWorkerUrl(window.URL.createObjectURL(new Blob([workerBundleString], { type: 'text/javascript' })));
```

MapLibre 6 is ESM-only and dropped that prelude in favour of sibling-URL resolution. `useInlinedMaplibreWorker()` restores what used to happen on its own. So every shipped release has been running a blob worker in the host, and the sandbox origin's CSP allows it explicitly — `worker-src 'self' https://www.claudeusercontent.com blob:`. Worth knowing that `script-src` there does *not* include `blob:`, so this rests on the explicit `worker-src` and not on a fallback; `worker-src` is also not expressible through the ext-apps `csp` field, so it is the host's policy that grants it rather than anything the server declares.

Because the fixture app and the 16 real apps build through the same config, `e2e/mapWorker.spec.ts` now covers the mechanism itself — with the plugin removed it fails on a 404 for `maplibre-gl-worker.mjs` and 0 rendered features.

## POI popups

`icon-opacity` and `text-opacity` exist only on symbol layers. The places source also carries `line` (`places-N-connection-line`) and `circle` (`places-N-clusterBadge`) layers, and MapLibre 6 throws from `getPaintProperty` for a property the layer type does not have:

```
TypeError: Cannot read properties of undefined (reading 'value')
    at getValue → getPaintProperty → setPaintProperty → onMapClick
```

`applyHidePaint()` sets the two properties on symbol layers only; badges and connection lines render no individual marker, so nothing is lost.

## maplibre-gl stays explicit

Kept as a direct devDependency at `^6.4.0` rather than left to the SDK's peer resolution: the apps import `Popup`, `Marker` and layer types straight from it, and a phantom dependency that gets bundled into every app would follow whatever the SDK happened to pull in.

## Size

The inlined worker is 459 KB minified and accounts for 460k of each map app. MapLibre 6 is itself ~85k smaller per app than 5, though, so the net cost against `main` is less than that:

| | `main` (maplibre 5) | maplibre 6, no inlining | this PR | vs `main` |
|---|---|---|---|---|
| `map/dynamic-map/app.html` | 1608k | 1536k | 1996k | **+388k** |
| `search/geocode/app.html` | 1472k | 1387k | 1847k | **+375k** |
| `search/poi-categories/app.html` (no map) | 335k | 335k | 335k | **—** |
| `dist/apps` (16 apps) | 22.1M | — | 27.6M | **+5.5M** |
| `.mcpb` (darwin-arm64) | 129.2 MB | — | 126.1 MB | **−3.1 MB** |

Sizes are KiB from `wc -c`, so the middle column is this branch with the plugin removed rather than a separate build of `main`. 15 apps carry the worker; `poi-categories` has no map and is unchanged. The shipped package gets **smaller**, measured by building both bundles. `build:mcpb` installs with `--prod`, which drops devDependencies, but maplibre-gl still lands in the bundle as a peer of `@tomtom-org/maps-sdk`, so the version swap counts:

| inside the `.mcpb`, unpacked | `main` | this PR |
|---|---|---|
| `node_modules/maplibre-gl` | 42.6 MB (5.24.0) | 18.5 MB (6.4.0) |
| the 16 `app.html` bundles | 22.1 MB | 27.6 MB |

−24.1 MB against +5.5 MB, which after zip compression nets out to a 3.1 MB (−2.4%) smaller bundle: 135,487,804 → 132,207,588 bytes.

## Resource reads

Each bundle was read from disk and decoded on **every** read of its `ui://` resource — ~2 MB per render for a map app now that the worker is inlined. The file only changes when `build:apps` runs, so `src/tools/helpers/appHtmlCache.ts` caches it per path.

Validated against mtime and size rather than cached outright. The `pnpm ui` loop runs the built server from `dist`, so rebuilding the apps under a live server currently shows up on the next read; a blind cache would serve the previous bundle until restart. A `stat` costs about 1% of what the read costs, so the check is close to free.

Only successful reads are cached, so a server started before `build:apps` ran picks the apps up once they exist instead of serving the `App not found` fallback forever.

| `map/dynamic-map` (2,024,562 bytes), median | |
|---|---|
| `readFile`, OS page cache warm | 2.66ms |
| `stat` — what replaces it on a hit | 0.022ms |
| end-to-end `readResource` through the built server | 12.5ms |

So ~2.6ms off a ~12.5ms read: the syscall, the 2 MB UTF-8 decode and a 2 MB allocation per render. The rest is JSON-RPC serialisation and pipe transfer of a 2 MB string, which caching cannot reach — only a smaller bundle or a compressed transport moves that.

`appHtmlCache.test.ts` runs against a real filesystem: a mocked `fs` would only report back whatever mtime and size the test had already chosen, and reacting to those is the entire behaviour. The "reads from disk once" test carries a control assertion that the spy **is** called after an invalidation, so it cannot pass vacuously if the spy is ever wired to the wrong object.

`resourceRegistry`'s two existing tests need their own app names: sharing one lets the first test's cached HTML satisfy the second, which then never reaches the failure path.

## The e2e test

`e2e/mapWorker.spec.ts` builds a fixture app through the same single-file Vite config the real apps use, serves only that one file (any other request 404s, like a host that can hand over a single HTML resource and nothing more), and asserts MapLibre actually rendered features from a local GeoJSON source. A GeoJSON source is the cheapest way to make the worker do real work: MapLibre hands the data over to be cut into tiles, so if the worker never starts, nothing renders.

On failure it reports the mechanism, not just an empty map:

```
Error: MapLibre rendered no features, so its worker never parsed the source.
A single-file app cannot fetch a worker from a sibling URL — the worker has to
be inlined into the bundle.
Expected: > 0
Received:   0
```

A failed fetch of any worker asset and any `Failed to construct 'Worker'` console error come first as supporting diagnostics. **No API key needed** — the style is inline and the data is local, so it runs in CI where the live-API specs skip. It needs WebGL2, so the spec sets `--use-gl=angle --enable-unsafe-swiftshader` via `test.use` rather than changing the shared config.

| | |
|---|---|
| `e2e/mapWorker.spec.ts` | the test |
| `e2e/fixtures/map-worker-app/{app.html,app.ts}` | fixture app; imports `maplibre-gl` exactly as the real apps do |
| `e2e/fixtures/map-worker-app/probe.ts` | types-only contract shared by fixture and spec |
| `scripts/appViteConfig.ts` | the apps' Vite options and the worker plugin, shared by `build:apps` and this test |
| `.github/workflows/quality_checks.yml` | runs this one spec in CI |

## Verification

Local, with a real API key:

- **e2e: 23/23 pass**, including every `show_ui: true` app spec — markers render and POI popups open on all 15 map apps, which is the worker doing its job in the shipped bundles
- **`mapWorker.spec.ts` passes with the plugin and fails without it**: 404 on `maplibre-gl-worker.mjs`, then 0 features
- Unit tests 511/511 (7 new for the bundle cache); `type-check` clean; Biome unchanged at 259 warnings / 20 infos
- Tool suites, Genesis: stdio 33 passed / 0 failed, http 58 / 0. Orbis: stdio 18 / 0, http 38 / 0
- `build` (16 apps, single `app.html` each), `ui:build` and `build:mcpb` all succeed
- `pnpm peers check` reports no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)





